### PR TITLE
Add support for table schemas in get_query_tables()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ install:
 	pip install -e .[dev]
 
 test:
-	pytest -v
+	pytest -vv
 
 coverage:
 	rm -f .coverage*
 	rm -rf htmlcov/*
-	coverage run -p -m pytest -v
+	coverage run -p -m pytest -vv
 	coverage combine
 	coverage html -d htmlcov $(coverage_options)
 	coverage xml -i

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ pip install sql_metadata
 >>> sql_metadata.get_query_columns("INSERT /* VoteHelper::addVote xxx */  INTO `page_vote` (article_id,user_id,`time`) VALUES ('442001','27574631','20180228130846')")
 ['article_id', 'user_id', 'time']
 
+>>> sql_metadata.get_query_columns("SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address")
+['a.*', 'a.ip_address', 'b.ip_address']
+
 >>> sql_metadata.get_query_tables("SELECT test, id FROM foo, bar")
 [u'foo', u'bar']
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ pip install sql_metadata
 >>> sql_metadata.get_query_columns("SELECT test, id FROM foo, bar")
 [u'test', u'id']
 
+>>> sql_metadata.get_query_tables("SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address")
+['product_a.users', 'product_b.users']
+
 >>> sql_metadata.get_query_columns("INSERT /* VoteHelper::addVote xxx */  INTO `page_vote` (article_id,user_id,`time`) VALUES ('442001','27574631','20180228130846')")
 ['article_id', 'user_id', 'time']
 

--- a/sql_metadata.py
+++ b/sql_metadata.py
@@ -133,13 +133,28 @@ def get_query_tables(query):
                                 'INTO', 'UPDATE'] \
                     and last_token not in ['AS'] \
                     and token.value not in ['AS', 'SELECT']:
-                table_name = str(token.value.strip('`'))
-                if table_name not in tables:
+
+                if last_token == '.':
+                    # we have database.table notation example
+                    # append table name to the last entry of tables
+                    # as it is a database name in fact
+                    database_name = tables[-1]
+                    tables[-1] = '{}.{}'.format(database_name, token)
+                else:
+                    table_name = str(token.value.strip('`'))
                     tables.append(table_name)
 
         last_token = token.value.upper()
 
-    return tables
+    # make tables list unique,
+    # but keep the order - list(set()) will not provide that
+    ret = []
+
+    for table in tables:
+        if table not in ret:
+            ret.append(table)
+
+    return ret
 
 
 def get_query_limit_and_offset(query):

--- a/sql_metadata.py
+++ b/sql_metadata.py
@@ -95,11 +95,11 @@ def get_query_columns(query):
                     if str(last_token) == '.':
                         # print('DOT', last_token, columns[-1])
 
-                        # we have database.table notation example
-                        # append table name to the last entry of columns
-                        # as it is a database name in fact
-                        database_name = columns[-1]
-                        columns[-1] = '{}.{}'.format(database_name, token)
+                        # we have table.column notation example
+                        # append column name to the last entry of columns
+                        # as it is a table name in fact
+                        table_name = columns[-1]
+                        columns[-1] = '{}.{}'.format(table_name, token)
                     else:
                         columns.append(str(token.value))
             elif last_keyword in ['INTO'] and last_token.ttype is Punctuation:
@@ -113,8 +113,8 @@ def get_query_columns(query):
 
                 if str(last_token) == '.':
                     # handle SELECT foo.*
-                    database_name = columns[-1]
-                    columns[-1] = '{}.{}'.format(database_name, str(token))
+                    table_name = columns[-1]
+                    columns[-1] = '{}.{}'.format(table_name, str(token))
                 else:
                     columns.append(str(token.value))
 

--- a/sql_metadata.py
+++ b/sql_metadata.py
@@ -9,6 +9,24 @@ from sqlparse.sql import TokenList
 from sqlparse.tokens import Name, Whitespace, Wildcard, Number, Punctuation
 
 
+def unique(_list):
+    """
+    Makes the list have unique items only and maintains the order
+
+    list(set()) won't provide that
+
+    :type _list list
+    :rtype: list
+    """
+    ret = []
+
+    for item in _list:
+        if item not in ret:
+            ret.append(item)
+
+    return ret
+
+
 def preprocess_query(query):
     """
     Perform initial query cleanup
@@ -146,15 +164,7 @@ def get_query_tables(query):
 
         last_token = token.value.upper()
 
-    # make tables list unique,
-    # but keep the order - list(set()) will not provide that
-    ret = []
-
-    for table in tables:
-        if table not in ret:
-            ret.append(table)
-
-    return ret
+    return unique(tables)
 
 
 def get_query_limit_and_offset(query):

--- a/sql_metadata.py
+++ b/sql_metadata.py
@@ -21,11 +21,11 @@ def preprocess_query(query):
     # INNER JOIN `fact_wam_scores` `fwN`
     query = re.sub(r'(\s(FROM|JOIN)\s`[^`]+`)\s`[^`]+`', r'\1', query, flags=re.IGNORECASE)
 
-    # 2. `database`.`table` notation -> table
-    query = re.sub(r'`([^`]+)`\.`([^`]+)`', r'\2', query)
+    # 2. `database`.`table` notation -> database.table
+    query = re.sub(r'`([^`]+)`\.`([^`]+)`', r'\1.\2', query)
 
-    # 2. `database`.`table` notation -> table
-    query = re.sub(r'([a-z_0-9]+)\.([a-z_0-9]+)', r'\2', query, flags=re.IGNORECASE)
+    # 2. database.table notation -> table
+    # query = re.sub(r'([a-z_0-9]+)\.([a-z_0-9]+)', r'\2', query, flags=re.IGNORECASE)
 
     return query
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -19,17 +19,17 @@ def test_get_query_tokens():
 
 def test_preprocess_query():
     assert preprocess_query('SELECT DISTINCT dw.lang FROM `dimension_wikis` `dw` INNER JOIN `fact_wam_scores` `fwN` ON ((dw.wiki_id = fwN.wiki_id)) WHERE fwN.time_id = FROM_UNIXTIME(N) ORDER BY dw.lang ASC') == \
-        'SELECT DISTINCT lang FROM `dimension_wikis` INNER JOIN `fact_wam_scores` ON ((wiki_id = wiki_id)) WHERE time_id = FROM_UNIXTIME(N) ORDER BY lang ASC'
+        'SELECT DISTINCT dw.lang FROM `dimension_wikis` INNER JOIN `fact_wam_scores` ON ((dw.wiki_id = fwN.wiki_id)) WHERE fwN.time_id = FROM_UNIXTIME(N) ORDER BY dw.lang ASC'
 
     assert preprocess_query("SELECT count(fwN.wiki_id) as wam_results_total FROM `fact_wam_scores` `fwN` left join `fact_wam_scores` `fwN` ON ((fwN.wiki_id = fwN.wiki_id) AND (fwN.time_id = FROM_UNIXTIME(N))) left join `dimension_wikis` `dw` ON ((fwN.wiki_id = dw.wiki_id)) WHERE (fwN.time_id = FROM_UNIXTIME(N)) AND (dw.url like X OR dw.title like X) AND fwN.vertical_id IN (XYZ) AND dw.lang = X AND (fwN.wiki_id NOT IN (XYZ)) AND ((dw.url IS NOT NULL AND dw.title IS NOT NULL))") == \
-        "SELECT count(wiki_id) as wam_results_total FROM `fact_wam_scores` left join `fact_wam_scores` ON ((wiki_id = wiki_id) AND (time_id = FROM_UNIXTIME(N))) left join `dimension_wikis` ON ((wiki_id = wiki_id)) WHERE (time_id = FROM_UNIXTIME(N)) AND (url like X OR title like X) AND vertical_id IN (XYZ) AND lang = X AND (wiki_id NOT IN (XYZ)) AND ((url IS NOT NULL AND title IS NOT NULL))"
+        "SELECT count(fwN.wiki_id) as wam_results_total FROM `fact_wam_scores` left join `fact_wam_scores` ON ((fwN.wiki_id = fwN.wiki_id) AND (fwN.time_id = FROM_UNIXTIME(N))) left join `dimension_wikis` ON ((fwN.wiki_id = dw.wiki_id)) WHERE (fwN.time_id = FROM_UNIXTIME(N)) AND (dw.url like X OR dw.title like X) AND fwN.vertical_id IN (XYZ) AND dw.lang = X AND (fwN.wiki_id NOT IN (XYZ)) AND ((dw.url IS NOT NULL AND dw.title IS NOT NULL))"
 
-    # remove database selector
+    # normalize database selector
     assert preprocess_query("SELECT foo FROM `db`.`test`") == \
-        "SELECT foo FROM test"
+        "SELECT foo FROM db.test"
 
     assert preprocess_query("SELECT r1.wiki_id AS id FROM report_wiki_recent_pageviews AS r1 INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id") == \
-        "SELECT wiki_id AS id FROM report_wiki_recent_pageviews AS r1 INNER JOIN dimension_wikis AS d ON wiki_id = wiki_id"
+        "SELECT r1.wiki_id AS id FROM report_wiki_recent_pageviews AS r1 INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id"
 
 
 def test_get_query_columns():

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -78,7 +78,9 @@ def test_get_query_tables():
 
     assert ['test_table'] == get_query_tables('SELECT foo FROM `test_table`')
 
-    assert ['test_table'] == get_query_tables('SELECT foo FROM `db`.`test_table`')
+    assert ['s.t'] == get_query_tables('SELECT * FROM s.t')
+
+    assert ['db.test_table'] == get_query_tables('SELECT foo FROM `db`.`test_table`')
 
     assert ['test_table'] == get_query_tables('SELECT foo FROM test_table WHERE id = 1')
 
@@ -99,7 +101,7 @@ def test_get_query_tables():
     assert ['fact_wam_scores', 'dimension_wikis'] == \
          get_query_tables("SELECT count(fwN.wiki_id) as wam_results_total FROM `fact_wam_scores` `fwN` left join `fact_wam_scores` `fwN` ON ((fwN.wiki_id = fwN.wiki_id) AND (fwN.time_id = FROM_UNIXTIME(N))) left join `dimension_wikis` `dw` ON ((fwN.wiki_id = dw.wiki_id)) WHERE (fwN.time_id = FROM_UNIXTIME(N)) AND (dw.url like X OR dw.title like X) AND fwN.vertical_id IN (XYZ) AND dw.lang = X AND (fwN.wiki_id NOT IN (XYZ)) AND ((dw.url IS NOT NULL AND dw.title IS NOT NULL))")
 
-    assert ['revision', 'page', 'user'] == \
+    assert ['revision', 'page', 'wikicities_cN.user'] == \
          get_query_tables("SELECT rev_id,rev_page,rev_text_id,rev_timestamp,rev_comment,rev_user_text,rev_user,rev_minor_edit,rev_deleted,rev_len,rev_parent_id,rev_shaN,page_namespace,page_title,page_id,page_latest,user_name FROM `revision` INNER JOIN `page` ON ((page_id = rev_page)) LEFT JOIN `wikicities_cN`.`user` ON ((rev_user != N) AND (user_id = rev_user)) WHERE rev_id = X LIMIT N")
 
     # complex queries, take two
@@ -138,6 +140,10 @@ def test_get_query_tables():
     # REPLACE queries
     assert ['page_props'] == \
         get_query_tables("REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) VALUES ('47','infoboxes','')")
+
+    # JOINs
+    assert ['product_a.users', 'product_b.users'] == \
+        get_query_tables("SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address")
 
 
 def test_joins():


### PR DESCRIPTION
Resolves #17

```python
>>> sql__metadata.get_query_tables("SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address")
['product_a.users', 'product_b.users']
```

and

```python
>>> sql_metadata.get_query_columns("SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address")
['a.*', 'a.ip_address', 'b.ip_address']
```