### PR TITLE
get_query_tables: Add support for `database.schema.table` notation

### DIFF
--- a/sql_metadata.py
+++ b/sql_metadata.py
@@ -190,10 +190,14 @@ def get_query_tables(query: str) -> List[str]:
                         tables[-1] = table_name
                     else:
                         tables.append(table_name)
-                if len(query_tokens) > 4 and query_tokens[i-4].ttype is Name and query_tokens[i-3].value == '.' \
-                        and query_tokens[i-2].ttype is Name and last_token == '.' and token.ttype is Name:
+                if len(query_tokens) > 4 and query_tokens[i-4].ttype is Name \
+                        and query_tokens[i-3].value == '.' \
+                        and query_tokens[i-2].ttype is Name \
+                        and last_token == '.' \
+                        and token.ttype is Name:
                     # we have database.schema.table notation example
-                    table_name = '{}.{}.{}'.format(query_tokens[i-4], query_tokens[i-2], query_tokens[i])
+                    table_name = '{}.{}.{}'.format(
+                        query_tokens[i-4], query_tokens[i-2], query_tokens[i])
                     if len(tables) > 0:
                         tables[-1] = table_name
                     else:

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -123,6 +123,36 @@ def test_get_query_tables():
     assert ['product_a.users', 'product_b.users'] == \
         get_query_tables("SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address")
 
+    # database.schema.table formats
+    assert ['MYDB1.MYSCHEMA1.MYTABLE1'] == get_query_tables('SELECT * FROM MYDB1.MYSCHEMA1.MYTABLE1')
+
+    assert ['MYDB1.MYSCHEMA1.MYTABLE1', 'MYDB2.MYSCHEMA2.MYTABLE2'] == get_query_tables('SELECT * FROM MYDB1.MYSCHEMA1.MYTABLE1 JOIN MYDB2.MYSCHEMA2.MYTABLE2')
+
+    assert ['MYDB1.MYSCHEMA1.MYTABLE1', 'MYDB2.MYSCHEMA2.MYTABLE2'] == get_query_tables('SELECT * FROM MYDB1.MYSCHEMA1.MYTABLE1 INNER JOIN MYDB2.MYSCHEMA2.MYTABLE2')
+
+    assert ['MYDB1.MYSCHEMA1.MYTABLE1', 'MYDB2.MYSCHEMA2.MYTABLE2'] == get_query_tables('SELECT * FROM MYDB1.MYSCHEMA1.MYTABLE1 A LEFT JOIN MYDB2.MYSCHEMA2.MYTABLE2 B ON A.COL = B.COL')
+
+    assert ['MYDB1.MYSCHEMA1.MYTABLE1', 'MYDB2.MYSCHEMA2.MYTABLE2'] == get_query_tables('SELECT * FROM MYDB1.MYSCHEMA1.MYTABLE1 INNER JOIN MYDB2.MYSCHEMA2.MYTABLE2')
+
+    # handle quoted names
+    assert ['MYDB.MYTABLE'] == get_query_tables('SELECT COUNT(*) FROM "MYDB".MYTABLE')
+
+    assert ['MYDB.MYTABLE'] == get_query_tables('SELECT COUNT(*) FROM MYDB."MYTABLE"')
+
+    assert ['MYDB.MYTABLE'] == get_query_tables('SELECT COUNT(*) FROM "MYDB"."MYTABLE"')
+
+    assert ['MYDB.MYSCHEMA.MYTABLE'] == get_query_tables('SELECT COUNT(*) FROM "MYDB".MYSCHEMA.MYTABLE')
+
+    assert ['MYDB.MYSCHEMA.MYTABLE'] == get_query_tables('SELECT COUNT(*) FROM MYDB."MYSCHEMA".MYTABLE')
+
+    assert ['MYDB.MYSCHEMA.MYTABLE'] == get_query_tables('SELECT COUNT(*) FROM MYDB.MYSCHEMA."MYTABLE"')
+
+    assert ['MYDB.MYSCHEMA.MYTABLE'] == get_query_tables('SELECT COUNT(*) FROM "MYDB"."MYSCHEMA"."MYTABLE"')
+
+    # include multiple FROM tables when they prefixed
+    # @see https://github.com/macbre/sql-metadata/issues/38
+    assert ['MYDB1.TABLE1', 'MYDB2.TABLE2'] == get_query_tables('SELECT A.FIELD1, B.FIELD1, (A.FIELD1 * B.FIELD1) AS QTY FROM MYDB1.TABLE1 AS A, MYDB2.TABLE2 AS B')
+
 
 def test_joins():
     assert ['redirect', 'page'] == \


### PR DESCRIPTION
This PR adds support for parsing `database.schema.table` notation in get_query_tables which is supported by some databases including Snowflake.