### PR TITLE
Resolve table aliases in get_query_columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/sql_metadata.svg)](https://pypi.python.org/pypi/sql_metadata)
 
 Uses tokenized query returned by [`python-sqlparse`](https://github.com/andialbrecht/sqlparse) and generates query metadata.
-Extracts column names and tables used by the query. Provides a helper for normalization of SQL queries.
+**Extracts column names and tables** used by the query. Provides a helper for **normalization of SQL queries** and **tables aliases resolving**.
 
 Supported queries syntax:
 
@@ -43,6 +43,9 @@ pip install sql_metadata
 
 >>> sql_metadata.get_query_limit_and_offset('SELECT foo_limit FROM bar_offset limit 2000,50')
 (50, 2000)
+
+>>> sql_metadata.get_query_table_aliases("SELECT test FROM foo AS f")
+{'f': 'foo'}
 ```
 
 > See `test/test_query.py` file for more examples of a bit more complex queries.

--- a/sql_metadata.py
+++ b/sql_metadata.py
@@ -302,7 +302,7 @@ def get_query_table_aliases(query: str) -> Dict[str, str]:
     for token in get_query_tokens(query):
         # print(token.ttype, token, last_table_name)
 
-        # TODO: handle "FROM foo alias" syntax (i.e, "AS" keyword is missing)
+        # handle "FROM foo alias" syntax (i.e, "AS" keyword is missing)
         # if last_table_name and token.ttype is Name:
         #     aliases[token.value] = last_table_name
         #     last_table_name = False

--- a/sql_metadata.py
+++ b/sql_metadata.py
@@ -300,6 +300,13 @@ def get_query_table_aliases(query: str) -> Dict[str, str]:
     last_table_name = None
 
     for token in get_query_tokens(query):
+        # print(token.ttype, token, last_table_name)
+
+        # TODO: handle "FROM foo alias" syntax (i.e, "AS" keyword is missing)
+        # if last_table_name and token.ttype is Name:
+        #     aliases[token.value] = last_table_name
+        #     last_table_name = False
+
         if last_keyword_token:
             if last_keyword_token.value.upper() in ['FROM', 'JOIN', 'INNER JOIN']:
                 last_table_name = token.value

--- a/test/test_aliases.py
+++ b/test/test_aliases.py
@@ -3,16 +3,17 @@ from sql_metadata import get_query_tables, get_query_columns, get_query_table_al
 
 def test_get_query_table_aliases():
     assert get_query_table_aliases('SELECT bar FROM foo') == {}
-    # assert get_query_table_aliases('SELECT bar FROM foo f') == {'f': 'foo'}
     assert get_query_table_aliases('SELECT bar FROM foo AS f') == {'f': 'foo'}
+    # assert get_query_table_aliases('SELECT bar FROM foo f') == {'f': 'foo'}
     assert get_query_table_aliases('SELECT bar AS value FROM foo AS f') == {'f': 'foo'}
     assert get_query_table_aliases('SELECT bar AS value FROM foo AS f INNER JOIN dimensions AS d ON f.id = d.id') == {'f': 'foo', 'd': 'dimensions'}
     assert get_query_table_aliases('SELECT e.foo FROM (SELECT * FROM bar) AS e'), 'Sub-query aliases are ignored'
+    # assert get_query_table_aliases('SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address') == {'a': 'product_a.users'}
 
 
 def test_select_aliases():
     assert get_query_columns('SELECT e.foo FROM bar AS e') == ['bar.foo']
-    assert get_query_columns('SELECT e.foo FROM bar e') == ['e.foo']
+    # assert get_query_columns('SELECT e.foo FROM bar e') == ['bar.foo']
 
 
 def test_tables_aliases_are_resolved():

--- a/test/test_aliases.py
+++ b/test/test_aliases.py
@@ -1,4 +1,9 @@
-from sql_metadata import get_query_tables, get_query_columns
+from sql_metadata import get_query_tables, get_query_columns, get_query_table_aliases
+
+
+def test_get_query_table_aliases():
+    assert get_query_table_aliases('SELECT bar FROM foo') == {}
+    assert get_query_table_aliases('SELECT bar FROM foo AS f') == {'f': 'foo'}
 
 
 def test_tables_aliases_are_resolved():
@@ -8,4 +13,5 @@ def test_tables_aliases_are_resolved():
     sql = "SELECT a.* FROM users1 AS a JOIN users2 AS b ON a.ip_address = b.ip_address"
 
     assert get_query_tables(sql) == ['users1', 'users2']
-    assert get_query_columns(sql) == ['users1.*', 'users1.ip_address', 'users2.ip_address'], 'Should resolve table aliases'
+    assert get_query_table_aliases(sql) == {'a': 'users1', 'b': 'users2'}
+    # assert get_query_columns(sql) == ['users1.*', 'users1.ip_address', 'users2.ip_address'], 'Should resolve table aliases'

--- a/test/test_aliases.py
+++ b/test/test_aliases.py
@@ -3,7 +3,15 @@ from sql_metadata import get_query_tables, get_query_columns, get_query_table_al
 
 def test_get_query_table_aliases():
     assert get_query_table_aliases('SELECT bar FROM foo') == {}
+    # assert get_query_table_aliases('SELECT bar FROM foo f') == {'f': 'foo'}
     assert get_query_table_aliases('SELECT bar FROM foo AS f') == {'f': 'foo'}
+    assert get_query_table_aliases('SELECT bar AS value FROM foo AS f') == {'f': 'foo'}
+    assert get_query_table_aliases('SELECT bar AS value FROM foo AS f INNER JOIN dimensions AS d ON f.id = d.id') == {'f': 'foo', 'd': 'dimensions'}
+
+
+def test_select_aliases():
+    assert get_query_columns('SELECT e.foo FROM bar AS e') == ['bar.foo']
+    # assert get_query_columns('SELECT e.foo FROM bar e') == ['bar.foo']
 
 
 def test_tables_aliases_are_resolved():
@@ -14,4 +22,4 @@ def test_tables_aliases_are_resolved():
 
     assert get_query_tables(sql) == ['users1', 'users2']
     assert get_query_table_aliases(sql) == {'a': 'users1', 'b': 'users2'}
-    # assert get_query_columns(sql) == ['users1.*', 'users1.ip_address', 'users2.ip_address'], 'Should resolve table aliases'
+    assert get_query_columns(sql) == ['users1.*', 'users1.ip_address', 'users2.ip_address'], 'Should resolve table aliases'

--- a/test/test_aliases.py
+++ b/test/test_aliases.py
@@ -7,11 +7,12 @@ def test_get_query_table_aliases():
     assert get_query_table_aliases('SELECT bar FROM foo AS f') == {'f': 'foo'}
     assert get_query_table_aliases('SELECT bar AS value FROM foo AS f') == {'f': 'foo'}
     assert get_query_table_aliases('SELECT bar AS value FROM foo AS f INNER JOIN dimensions AS d ON f.id = d.id') == {'f': 'foo', 'd': 'dimensions'}
+    assert get_query_table_aliases('SELECT e.foo FROM (SELECT * FROM bar) AS e'), 'Sub-query aliases are ignored'
 
 
 def test_select_aliases():
     assert get_query_columns('SELECT e.foo FROM bar AS e') == ['bar.foo']
-    # assert get_query_columns('SELECT e.foo FROM bar e') == ['bar.foo']
+    assert get_query_columns('SELECT e.foo FROM bar e') == ['e.foo']
 
 
 def test_tables_aliases_are_resolved():

--- a/test/test_aliases.py
+++ b/test/test_aliases.py
@@ -8,7 +8,7 @@ def test_get_query_table_aliases():
     assert get_query_table_aliases('SELECT bar AS value FROM foo AS f') == {'f': 'foo'}
     assert get_query_table_aliases('SELECT bar AS value FROM foo AS f INNER JOIN dimensions AS d ON f.id = d.id') == {'f': 'foo', 'd': 'dimensions'}
     assert get_query_table_aliases('SELECT e.foo FROM (SELECT * FROM bar) AS e'), 'Sub-query aliases are ignored'
-    # assert get_query_table_aliases('SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address') == {'a': 'product_a.users'}
+    assert get_query_table_aliases('SELECT a.* FROM product_a AS a JOIN product_b AS b ON a.ip_address = b.ip_address') == {'a': 'product_a', 'b': 'product_b'}
 
 
 def test_select_aliases():

--- a/test/test_aliases.py
+++ b/test/test_aliases.py
@@ -1,0 +1,11 @@
+from sql_metadata import get_query_tables, get_query_columns
+
+
+def test_tables_aliases_are_resolved():
+    """
+    See https://github.com/macbre/sql-metadata/issues/52
+    """
+    sql = "SELECT a.* FROM users1 AS a JOIN users2 AS b ON a.ip_address = b.ip_address"
+
+    assert get_query_tables(sql) == ['users1', 'users2']
+    assert get_query_columns(sql) == ['users1.*', 'users1.ip_address', 'users2.ip_address'], 'Should resolve table aliases'

--- a/test/test_get_query_columns.py
+++ b/test/test_get_query_columns.py
@@ -29,7 +29,7 @@ def test_get_query_columns_complex():
     assert get_query_columns("SELECT r.wiki_id AS id, pageviews_7day AS pageviews FROM report_wiki_recent_pageviews AS r "
         "INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id WHERE d.is_public = '1' "
         "AND r.lang IN ( 'en', 'ru' ) AND r.hub_name = 'gaming' ORDER BY pageviews DESC LIMIT 300") \
-        == ['r.wiki_id', 'pageviews_7day', 'd.wiki_id', 'd.is_public', 'r.lang', 'r.hub_name', 'pageviews']
+        == ['report_wiki_recent_pageviews.wiki_id', 'pageviews_7day', 'dimension_wikis.wiki_id', 'dimension_wikis.is_public', 'report_wiki_recent_pageviews.lang', 'report_wiki_recent_pageviews.hub_name', 'pageviews']
 
     # self joins
     assert get_query_columns("SELECT  count(fw1.wiki_id) as wam_results_total  FROM `fact_wam_scores` `fw1` "
@@ -50,12 +50,5 @@ def test_get_query_columns_complex():
     assert get_query_columns("REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) VALUES ('47','infoboxes','')") == ['pp_page', 'pp_propname', 'pp_value']
 
     # JOINs
-    assert ['a.*', 'a.ip_address', 'b.ip_address'] == \
+    assert ['product_a.*', 'product_a.ip_address', 'product_b.ip_address'] == \
         get_query_columns("SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address")
-
-
-def test_select_aliases():
-    assert get_query_columns('SELECT e.foo FROM bar AS e') == ['e.foo']
-    assert get_query_columns('SELECT e.foo FROM bar e') == ['e.foo']
-    assert get_query_columns('SELECT e.foo FROM (SELECT * FROM bar) AS e') == ['e.foo', '*']
-    assert get_query_columns('SELECT e.foo FROM (SELECT * FROM bar) e') == ['e.foo', '*']

--- a/test/test_get_query_columns.py
+++ b/test/test_get_query_columns.py
@@ -48,7 +48,3 @@ def test_get_query_columns_complex():
 
     # REPLACE queries
     assert get_query_columns("REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) VALUES ('47','infoboxes','')") == ['pp_page', 'pp_propname', 'pp_value']
-
-    # JOINs
-    assert ['product_a.*', 'product_a.ip_address', 'product_b.ip_address'] == \
-        get_query_columns("SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address")


### PR DESCRIPTION
```python
sql = "SELECT a.* FROM users1 AS a JOIN users2 AS b ON a.ip_address = b.ip_address"

get_query_columns(sql)  # should return ['users1.*', 'users1.ip_address', 'users2.ip_address']
```

And introduce `get_query_table_aliases`:

```python
>>> sql_metadata.get_query_table_aliases("SELECT test FROM foo AS f")
{'f': 'foo'}
```

Resolves #52

However the following aliases syntax is not yet supported (missing `AS` keyword):

```sql
SELECT foo FROM test t`
```