### PR TITLE
get_query_columns: improve handling of queries with "IS NULL" conditions

### DIFF
--- a/sql_metadata.py
+++ b/sql_metadata.py
@@ -83,7 +83,9 @@ def get_query_columns(query: str) -> List[str]:
 
     # these keywords should not change the state of a parser
     # and not "reset" previously found SELECT keyword
-    keywords_ignored = ['AS', 'AND', 'OR', 'IN', 'IS', 'NOT', 'NOT NULL', 'LIKE', 'CASE', 'WHEN']
+    keywords_ignored = [
+        'AS', 'AND', 'OR', 'IN', 'IS', 'NULL', 'NOT', 'NOT NULL', 'LIKE', 'CASE', 'WHEN'
+    ]
 
     # these function should be ignored
     # and not "reset" previously found SELECT keyword

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -375,3 +375,13 @@ def test_datasets():
 
 def test_table_names_with_dashes():
     assert get_query_tables('SELECT * FROM `schema-with-dash.tablename`') == ['schema-with-dash.tablename']
+
+
+def test_queries_with_null_conditions():
+    assert get_query_columns(
+        'SELECT id FROM cm WHERE cm.status = 1 AND cm.OPERATIONDATE IS NULL AND cm.OID IN(123123);'
+    ) == ['id', 'cm.status', 'cm.OPERATIONDATE', 'cm.OID']
+
+    assert get_query_columns(
+        'SELECT id FROM cm WHERE cm.status = 1 AND cm.OPERATIONDATE IS NOT NULL AND cm.OID IN(123123);'
+    ) == ['id', 'cm.status', 'cm.OPERATIONDATE', 'cm.OID']


### PR DESCRIPTION
Bug reported and fix suggested by Levent Koc

```python
    assert get_query_columns(
        'SELECT id FROM cm WHERE cm.status = 1 AND cm.OPERATIONDATE IS NULL AND cm.OID IN(123123);'
    ) == ['id', 'cm.status', 'cm.OPERATIONDATE', 'cm.OID']
```

Before the fix `cm.OID` was not among the returned columns.