### PR TITLE
 Fixes macbre/sql-metadata#80; fixes macbre/sql-metadata#79

### DIFF
--- a/sql_metadata.py
+++ b/sql_metadata.py
@@ -170,7 +170,7 @@ def get_query_columns(query: str) -> List[str]:
     return unique(columns)
 
 
-def _get_token_normalized_value(token):
+def _get_token_normalized_value(token: str) -> str:
     return token.value.translate(str.maketrans("", "", " \n\t\r")).upper()
 
 

--- a/sql_metadata.py
+++ b/sql_metadata.py
@@ -171,7 +171,8 @@ def get_query_columns(query: str) -> List[str]:
 
 
 def _get_token_normalized_value(token):
-    return token.value.translate(str.maketrans('', '', ' \n\t\r')).upper()
+    return token.value.translate(str.maketrans("", "", " \n\t\r")).upper()
+
 
 def _update_table_names(
     tables: List[str], tokens: List[sqlparse.sql.Token], index: int, last_keyword: str
@@ -289,8 +290,8 @@ def get_query_tables(query: str) -> List[str]:
     for index, token in enumerate(tokens):
         # print([token, token.ttype, last_token, last_keyword])
 
-        #remove whitespaces from token value and uppercase
-        token_val_norm=_get_token_normalized_value(token)
+        # remove whitespaces from token value and uppercase
+        token_val_norm = _get_token_normalized_value(token)
         if token.is_keyword and token_val_norm in table_syntax_keywords:
             # keep the name of the last keyword, the next one can be a table name
             last_keyword = token_val_norm

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -206,6 +206,20 @@ def test_get_query_tables():
         "SELECT A.FIELD1, B.FIELD1, (A.FIELD1 * B.FIELD1) AS QTY FROM MYDB1.TABLE1 AS A, MYDB2.TABLE2 AS B"
     )
 
+    # test query with union
+    # @see https://github.com/macbre/sql-metadata/issues/79
+    assert ["tab1", "tab2"] == get_query_tables(
+        "select col1, col2, col3 from tab1 union all select col4, col5, col6 from tab2"
+    )
+
+    # test whitespaces in keywords
+    # @see https://github.com/macbre/sql-metadata/issues/80
+    assert ["tab","tab2"] == get_query_tables(
+        """select a,b,c from tab full  outer \r\n\t  join tab2  on (col1 = col2) group   
+               \r\n   \t   by  a, b, c """
+    )
+
+
 
 def test_case_insensitive():
     # case-insensitive handling

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -214,11 +214,10 @@ def test_get_query_tables():
 
     # test whitespaces in keywords
     # @see https://github.com/macbre/sql-metadata/issues/80
-    assert ["tab","tab2"] == get_query_tables(
+    assert ["tab", "tab2"] == get_query_tables(
         """select a,b,c from tab full  outer \r\n\t  join tab2  on (col1 = col2) group   
                \r\n   \t   by  a, b, c """
     )
-
 
 
 def test_case_insensitive():


### PR DESCRIPTION
I have fixed issue with additional whitespaces in multiple word keywords (like GROUP BY, INNER JOIN etc) and also issue with queries with UNION