### PR TITLE
Actions - allow to be run for PR from forked repo

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,7 +3,7 @@ name: Code formatting
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -6,7 +6,7 @@ name: Tests
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
 
 jobs:
   test:


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-events-for-forked-repositories

This should solve an issue with CI Actions not being executed for pull requests from forks.