### PR TITLE
Introduce a compatibility layer for 1.x functions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,31 @@ parser.comments
 
 See `test/test_normalization.py` file for more examples of a bit more complex queries.
 
+## Migrating from `sql_metadata` 1.x
+
+`sql_metadata.compat` module has been implemented to make the introduction of sql-metadata v2.0 smoother.
+
+You can use it by simply changing the imports in your code from:
+
+```python
+from sql_metadata import get_query_columns, get_query_tables
+```
+
+into:
+
+```python
+from sql_metadata.compat import get_query_columns, get_query_tables
+```
+
+The following functions from the old API are available in the `sql_metadata.compat` module:
+
+* `generalize_sql`
+* `get_query_columns`
+* `get_query_limit_and_offset`
+* `get_query_tables`
+* `get_query_tokens`
+* `preprocess_query`
+
 ## Stargazers over time
 
 [![Stargazers over time](https://starchart.cc/macbre/sql-metadata.svg)](https://starchart.cc/macbre/sql-metadata)

--- a/sql_metadata/compat.py
+++ b/sql_metadata/compat.py
@@ -1,0 +1,39 @@
+"""
+This module provides a temporary compatibility layer for legacy API dating back to 1.x version.
+
+Change your old imports:
+
+from sql_metadata import get_query_columns, get_query_tables
+
+into:
+
+from sql_metadata.compat import get_query_columns, get_query_tables
+
+"""
+from typing import List, Optional, Tuple
+
+import sqlparse
+
+
+def preprocess_query(query: str) -> str:
+    pass
+
+
+def get_query_tokens(query: str)  -> List[sqlparse.sql.Token]:
+    pass
+
+
+def get_query_columns(query: str) -> List[str]:
+    pass
+
+
+def get_query_tables(query: str) -> List[str]:
+    pass
+
+
+def get_query_limit_and_offset(query: str) -> Optional[Tuple[int, int]]:
+    pass
+
+
+def generalize_sql(sql: Optional[str]) -> Optional[str]:
+    pass

--- a/sql_metadata/compat.py
+++ b/sql_metadata/compat.py
@@ -10,30 +10,36 @@ into:
 from sql_metadata.compat import get_query_columns, get_query_tables
 
 """
+# pylint:disable=missing-function-docstring
 from typing import List, Optional, Tuple
 
 import sqlparse
+
+from sql_metadata import Parser
 
 
 def preprocess_query(query: str) -> str:
     pass
 
 
-def get_query_tokens(query: str)  -> List[sqlparse.sql.Token]:
+def get_query_tokens(query: str) -> List[sqlparse.sql.Token]:
     pass
 
 
 def get_query_columns(query: str) -> List[str]:
-    pass
+    return Parser(query).columns
 
 
 def get_query_tables(query: str) -> List[str]:
-    pass
+    return Parser(query).tables
 
 
 def get_query_limit_and_offset(query: str) -> Optional[Tuple[int, int]]:
-    pass
+    return Parser(query).limit_and_offset
 
 
 def generalize_sql(sql: Optional[str]) -> Optional[str]:
+    if sql is None:
+        return None
+
     pass

--- a/sql_metadata/compat.py
+++ b/sql_metadata/compat.py
@@ -14,6 +14,8 @@ from sql_metadata.compat import get_query_columns, get_query_tables
 from typing import List, Optional, Tuple
 
 import sqlparse
+from sqlparse.sql import TokenList
+from sqlparse.tokens import Whitespace
 
 from sql_metadata import Parser
 
@@ -23,7 +25,16 @@ def preprocess_query(query: str) -> str:
 
 
 def get_query_tokens(query: str) -> List[sqlparse.sql.Token]:
-    pass
+    query = preprocess_query(query)
+    parsed = sqlparse.parse(query)
+
+    # handle empty queries (#12)
+    if not parsed:
+        return []
+
+    tokens = TokenList(parsed[0].tokens).flatten()
+
+    return [token for token in tokens if token.ttype is not Whitespace]
 
 
 def get_query_columns(query: str) -> List[str]:

--- a/sql_metadata/compat.py
+++ b/sql_metadata/compat.py
@@ -19,7 +19,7 @@ from sql_metadata import Parser
 
 
 def preprocess_query(query: str) -> str:
-    pass
+    return Parser(query).query
 
 
 def get_query_tokens(query: str) -> List[sqlparse.sql.Token]:
@@ -38,8 +38,8 @@ def get_query_limit_and_offset(query: str) -> Optional[Tuple[int, int]]:
     return Parser(query).limit_and_offset
 
 
-def generalize_sql(sql: Optional[str]) -> Optional[str]:
-    if sql is None:
+def generalize_sql(query: Optional[str] = None) -> Optional[str]:
+    if query is None:
         return None
 
-    pass
+    return Parser(query).generalize

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -462,7 +462,7 @@ class Parser:  # pylint: disable=R0902
         return Generalizator(self._raw_query).without_comments
 
     @property
-    def generalize(self) -> Optional[str]:
+    def generalize(self) -> str:
         """
         Removes most variables from an SQL query
         and replaces them with X or N for numbers.

--- a/test/test_compat.py
+++ b/test/test_compat.py
@@ -1,0 +1,25 @@
+from sql_metadata.compat import (
+    get_query_columns,
+    get_query_tables,
+    get_query_limit_and_offset,
+)
+
+
+def test_get_query_columns():
+    assert ["*"] == get_query_columns("SELECT * FROM `test_table`")
+    assert ["foo", "id"] == get_query_columns(
+        "SELECT foo, count(*) as bar FROM `test_table` WHERE id = 3"
+    )
+
+
+def test_get_query_tables():
+    assert ["test_table"] == get_query_tables("SELECT * FROM `test_table`")
+    assert ["test_table", "second_table"] == get_query_tables(
+        "SELECT foo FROM test_table, second_table WHERE id = 1"
+    )
+
+
+def test_get_query_limit_and_offset():
+    assert (200, 927600) == get_query_limit_and_offset(
+        "SELECT * FOO foo LIMIT 927600,200"
+    )

--- a/test/test_compat.py
+++ b/test/test_compat.py
@@ -2,6 +2,8 @@ from sql_metadata.compat import (
     get_query_columns,
     get_query_tables,
     get_query_limit_and_offset,
+    generalize_sql,
+    preprocess_query,
 )
 
 
@@ -22,4 +24,22 @@ def test_get_query_tables():
 def test_get_query_limit_and_offset():
     assert (200, 927600) == get_query_limit_and_offset(
         "SELECT * FOO foo LIMIT 927600,200"
+    )
+
+
+def test_generalize_sql():
+    assert generalize_sql() is None
+    assert "SELECT * FROM foo;" == generalize_sql("SELECT * FROM foo;")
+    assert "SELECT * FROM foo WHERE id = N" == generalize_sql(
+        "SELECT * FROM foo WHERE id = 123"
+    )
+    assert "SELECT test FROM foo" == generalize_sql("SELECT /* foo */ test FROM foo")
+
+
+def test_preprocess_query():
+    assert "SELECT * FROM foo WHERE id = 123" == preprocess_query(
+        "SELECT * FROM foo WHERE id = 123"
+    )
+    assert "SELECT /* foo */ test FROM foo.bar" == preprocess_query(
+        "SELECT /* foo */ test\nFROM `foo`.`bar`"
     )

--- a/test/test_compat.py
+++ b/test/test_compat.py
@@ -1,9 +1,12 @@
+from sqlparse.tokens import Punctuation, Wildcard
+
 from sql_metadata.compat import (
     get_query_columns,
     get_query_tables,
     get_query_limit_and_offset,
     generalize_sql,
     preprocess_query,
+    get_query_tokens,
 )
 
 
@@ -43,3 +46,16 @@ def test_preprocess_query():
     assert "SELECT /* foo */ test FROM foo.bar" == preprocess_query(
         "SELECT /* foo */ test\nFROM `foo`.`bar`"
     )
+
+
+def test_get_query_tokens():
+    tokens = get_query_tokens("SELECT * FROM foo;")
+    assert len(tokens) == 5
+
+    assert tokens[0].normalized == "SELECT"
+    assert tokens[1].ttype is Wildcard
+    assert tokens[2].normalized == "FROM"
+    assert tokens[3].normalized == "foo"
+    assert tokens[4].ttype is Punctuation
+
+    assert [] == get_query_tokens("")


### PR DESCRIPTION
In order to make the introduction of sql-metadata v2.0 smoother a compatibility layer has been introduced. You can use it by simply changing the imports in your code:

```python
from sql_metadata import get_query_columns, get_query_tables
```
into:

```python
from sql_metadata.compat import get_query_columns, get_query_tables
```

The following functions are available in `sql_metadata.compat` module:

* `generalize_sql`
* `get_query_columns`
* `get_query_limit_and_offset`
* `get_query_tables`
* `get_query_tokens`
* `preprocess_query`

/cc @collerek 