### PR TITLE
Resolving subqueries columns

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -69,7 +69,7 @@ jobs:
       if: matrix.python-version == '3.9'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: poetry run coveralls
+      run: poetry run coveralls --service=github
 
     - name: Lint with pylint
       run: make lint

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Upload coverage report to Coveralls
       if: matrix.python-version == '3.9'
       env:
-        GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: poetry run coveralls
 
     - name: Lint with pylint

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Upload coverage report to Coveralls
       if: matrix.python-version == '3.9'
       env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: poetry run coveralls
 
     - name: Lint with pylint

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ parser.columns
 # ["foo.test"]
 ```
 
-### Extracting values from query
+### Extracting values from insert query
 ```python
 from sql_metadata import Parser
 
@@ -198,16 +198,17 @@ parser.subqueries
 parser.subqueries_names
 # ["a", "b"]
 
-# note that you can also exclude columns coming from sub-queries
-# all columns
+# note that columns coming from sub-queries are resolved to real columns
 parser.columns
 #["some_task_detail.task_id", "some_task_detail.STATUS", "some_task.task_id", 
-# "task_type_id", "a.task_id", "b.task_id"]
-
-# without subqueries
-parser.columns_without_subqueries
-#["some_task_detail.task_id", "some_task_detail.STATUS", "some_task.task_id", 
 # "task_type_id"]
+
+# same applies for columns_dict, note the join columns are resolved
+parser.columns_dict
+#{'join': ['some_task_detail.task_id', 'some_task.task_id'],
+# 'select': ['some_task_detail.task_id', 'some_task.task_id'],
+# 'where': ['some_task_detail.STATUS', 'task_type_id']}
+
 ```
 
 See `tests` file for more examples of a bit more complex queries.

--- a/README.md
+++ b/README.md
@@ -7,13 +7,21 @@
 [![Downloads](https://pepy.tech/badge/sql-metadata/month)](https://pepy.tech/project/sql-metadata)
 
 Uses tokenized query returned by [`python-sqlparse`](https://github.com/andialbrecht/sqlparse) and generates query metadata.
-**Extracts column names and tables** used by the query. Provides a helper for **normalization of SQL queries** and **tables aliases resolving**.
+
+**Extracts column names and tables** used by the query. 
+Automatically conduct **column alias resolution**, **sub queries aliases resolution** as well as **tables aliases resolving**.
+
+Provides also a helper for **normalization of SQL queries**.
 
 Supported queries syntax:
 
 * MySQL
 * PostgreSQL
+* Sqlite
+* MSSQL
 * [Apache Hive](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DML)
+
+(note that listed backends can differ quite substantially but should work in regard of query types supported by `sql-metadata`)
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sql_metadata"
-version = "2.0.0"
+version = "2.1.0"
 license="MIT"
 description = "Uses tokenized query returned by python-sqlparse and generates query metadata"
 authors = ["Maciej Brencz <maciej.brencz@gmail.com>"]

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -736,10 +736,10 @@ class Parser:  # pylint: disable=R0902
         parts = subquery_alias.split(".")
         if len(parts) != 2 or parts[0] not in self.subqueries_names:
             return [subquery_alias]
-        sub_qry, column_name = parts[0], parts[-1]
-        sub_qry_definition = self.subqueries.get(sub_qry)
+        sub_query, column_name = parts[0], parts[-1]
+        sub_query_definition = self.subqueries.get(sub_query)
         subparser = self._subqueries_parsers.setdefault(
-            sub_qry, Parser(sub_qry_definition)
+            sub_query, Parser(sub_query_definition)
         )
         # in subquery you cannot have more than one column with given name
         # so it either has to have an alias or only one column with given name exists

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -756,9 +756,7 @@ class Parser:  # pylint: disable=R0902
             return subparser.columns
         column_index = [x.split(".")[-1] for x in subparser.columns].index(column_name)
         resolved_column = subparser.columns[column_index]
-        return (
-            resolved_column if isinstance(resolved_column, list) else [resolved_column]
-        )
+        return [resolved_column]
 
     def _determine_opening_parenthesis_type(self, token: SQLToken):
         """

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -20,7 +20,7 @@ from sql_metadata.keywords_lists import (
     WITH_ENDING_KEYWORDS,
 )
 from sql_metadata.token import EmptyToken, SQLToken
-from sql_metadata.utils import UniqueList
+from sql_metadata.utils import UniqueList, flatten_list
 
 
 class Parser:  # pylint: disable=R0902
@@ -48,6 +48,7 @@ class Parser:  # pylint: disable=R0902
         self._with_names = None
         self._subqueries = None
         self._subqueries_names = None
+        self._subqueries_parsers = dict()
 
         self._limit_and_offset = None
 
@@ -206,11 +207,12 @@ class Parser:  # pylint: disable=R0902
                         and not token.next_token.is_left_parenthesis
                     ):
                         column = token.table_prefixed_column(tables_aliases)
-                        self._columns_with_tables_aliases[token.left_expanded] = column
+                        column = self._resolve_subquery_alias_to_column(column)
+                        self._add_to_columns_with_tables(token, column)
                         self._add_to_columns_subsection(
                             keyword=token.last_keyword_normalized, column=column
                         )
-                        columns.append(column)
+                        columns.extend(column)
                 elif (
                     token.last_keyword_normalized == "INTO"
                     and token.previous_token.is_punctuation
@@ -230,11 +232,12 @@ class Parser:  # pylint: disable=R0902
             ):
                 # handle * wildcard in select part, but ignore count(*)
                 column = token.table_prefixed_column(tables_aliases)
-                self._columns_with_tables_aliases[token.left_expanded] = column
+                column = self._resolve_subquery_alias_to_column(column)
+                self._add_to_columns_with_tables(token, column)
                 self._add_to_columns_subsection(
                     keyword=token.last_keyword_normalized, column=column
                 )
-                columns.append(column)
+                columns.extend(column)
 
         self._columns = columns
         return self._columns
@@ -292,6 +295,7 @@ class Parser:  # pylint: disable=R0902
                 token.value in self.columns_aliases_names
                 and token.value not in column_aliases
                 and not token.previous_token.is_nested_function_start
+                and token.is_alias_definition
             ):
                 if token.previous_token.normalized == "AS":
                     token_check = token.get_nth_previous(2)
@@ -305,7 +309,9 @@ class Parser:  # pylint: disable=R0902
                     if start_token.next_token.normalized == "SELECT":
                         # we have a subquery
                         alias_token = start_token.next_token.find_nearest_token(
-                            self._aliases_to_check, direction="right"
+                            self._aliases_to_check,
+                            direction="right",
+                            value_attribute="left_expanded",
                         )
                         alias_of = self._resolve_alias_to_column(alias_token)
                     else:
@@ -368,10 +374,8 @@ class Parser:  # pylint: disable=R0902
             ) and not token.next_token.is_dot:
                 if (
                     token.last_keyword_normalized in KEYWORDS_BEFORE_COLUMNS
-                    and (
-                        token.previous_token.normalized in ["AS", ")"]
-                        or token.is_alias_without_as
-                    )
+                    and token.normalized not in ["DIV"]
+                    and token.is_alias_definition
                     or token.is_in_with_columns
                 ) and token.value not in with_names + subqueries_names:
                     alias = token.left_expanded
@@ -669,13 +673,17 @@ class Parser:  # pylint: disable=R0902
         """
         return Generalizator(self._raw_query).generalize
 
-    def _add_to_columns_subsection(self, keyword: str, column: str):
+    def _add_to_columns_subsection(self, keyword: str, column: Union[str, List[str]]):
         """
         Add columns to the section in which it appears in query
         """
         section = COLUMNS_SECTIONS[keyword]
         self._columns_dict = self._columns_dict or dict()
-        self._columns_dict.setdefault(section, UniqueList()).append(column)
+        current_section = self._columns_dict.setdefault(section, UniqueList())
+        if isinstance(column, str):
+            current_section.append(column)
+        else:
+            current_section.extend(column)
 
     def _add_to_columns_aliases_subsection(self, token: SQLToken):
         """
@@ -692,16 +700,23 @@ class Parser:  # pylint: disable=R0902
         self._columns_aliases_dict = self._columns_aliases_dict or dict()
         self._columns_aliases_dict.setdefault(section, UniqueList()).append(alias)
 
-    def _resolve_column_alias(self, alias: str) -> str:
+    def _add_to_columns_with_tables(
+        self, token: SQLToken, column: Union[str, List[str]]
+    ) -> None:
+        if isinstance(column, list) and len(column) == 1:
+            column = column[0]
+        self._columns_with_tables_aliases[token.left_expanded] = column
+
+    def _resolve_column_alias(self, alias: Union[str, List[str]]) -> Union[str, List]:
         """
         Returns a column name for a given alias
         """
+        if isinstance(alias, list):
+            return [self._resolve_column_alias(x) for x in alias]
         while alias in self.columns_aliases:
             alias = self.columns_aliases[alias]
             if isinstance(alias, list):
-                break
-        if isinstance(alias, list):
-            alias = [self._resolve_column_alias(x) for x in alias]
+                return self._resolve_column_alias(alias)
         return alias
 
     def _resolve_alias_to_column(self, alias_token: SQLToken) -> str:
@@ -713,6 +728,37 @@ class Parser:  # pylint: disable=R0902
         else:
             alias_of = alias_token.left_expanded
         return alias_of
+
+    def _resolve_subquery_alias_to_column(self, subquery_alias) -> List[str]:
+        """
+        Resolves subquery reference to the actual column in the subquery
+        """
+        parts = subquery_alias.split(".")
+        if len(parts) != 2 or parts[0] not in self.subqueries_names:
+            return [subquery_alias]
+        sub_qry, column_name = parts[0], parts[-1]
+        sub_qry_definition = self.subqueries.get(sub_qry)
+        subparser = self._subqueries_parsers.setdefault(
+            sub_qry, Parser(sub_qry_definition)
+        )
+        # in subquery you cannot have more than one column with given name
+        # so it either has to have an alias or only one column with given name exists
+        if column_name in subparser.columns_aliases_names:
+            resolved_column = subparser._resolve_column_alias(  # pylint: disable=W0212
+                column_name
+            )
+            if isinstance(resolved_column, list):
+                resolved_column = flatten_list(resolved_column)
+                return resolved_column
+            return [resolved_column]
+
+        if column_name == "*":
+            return subparser.columns
+        column_index = [x.split(".")[-1] for x in subparser.columns].index(column_name)
+        resolved_column = subparser.columns[column_index]
+        return (
+            resolved_column if isinstance(resolved_column, list) else [resolved_column]
+        )
 
     def _determine_opening_parenthesis_type(self, token: SQLToken):
         """
@@ -784,7 +830,11 @@ class Parser:  # pylint: disable=R0902
         while loop_token.next_token != end_token:
             if loop_token.next_token.left_expanded in self._aliases_to_check:
                 alias_token = loop_token.next_token
-                aliases.append(self._resolve_alias_to_column(alias_token))
+                if (
+                    alias_token.normalized != "*"
+                    or alias_token.is_wildcard_not_operator
+                ):
+                    aliases.append(self._resolve_alias_to_column(alias_token))
             loop_token = loop_token.next_token
         return aliases[0] if len(aliases) == 1 else aliases
 

--- a/sql_metadata/token.py
+++ b/sql_metadata/token.py
@@ -181,7 +181,12 @@ class SQLToken:  # pylint: disable=R0902
         """
         Returns if current token is a definition of an alias.
         Note that aliases can also be used in other queries and be a part
-        of other nested columns with aliases
+        of other nested columns with aliases.
+
+        Note that this function only check if alias token is a token with
+        alias definition, it's not suitable for determining IF token is an alias
+        as it's more complicated and this method would match
+        also i.e. sub-queries names
         """
         return (
             self.is_alias_without_as

--- a/sql_metadata/utils.py
+++ b/sql_metadata/utils.py
@@ -1,7 +1,7 @@
 """
 Module with various utils
 """
-from typing import Any, List
+from typing import Any, List, Sequence
 
 
 class UniqueList(list):

--- a/sql_metadata/utils.py
+++ b/sql_metadata/utils.py
@@ -13,5 +13,22 @@ class UniqueList(list):
         if item not in self:
             super().append(item)
 
+    def extend(self, items: Any) -> None:
+        for item in items:
+            self.append(item)
+
     def __sub__(self, other) -> List:
         return [x for x in self if x not in other]
+
+
+def flatten_list(input_list: List) -> List[str]:
+    """
+    Flattens list of string and lists if there are nested lists.
+    """
+    result = []
+    for item in input_list:
+        if isinstance(item, list):
+            result.extend(flatten_list(item))
+        else:
+            result.append(item)
+    return result

--- a/sql_metadata/utils.py
+++ b/sql_metadata/utils.py
@@ -13,7 +13,7 @@ class UniqueList(list):
         if item not in self:
             super().append(item)
 
-    def extend(self, items: Any) -> None:
+    def extend(self, items: Sequence[Any]) -> None:
         for item in items:
             self.append(item)
 

--- a/test/test_column_aliases.py
+++ b/test/test_column_aliases.py
@@ -37,7 +37,6 @@ order by 1, 2;
         "ContractID",
         "StartDate",
         "EndDate",
-        "sq.BusinessSource",
         "data_contracts_report.BusinessSource",
     ]
     assert parser.columns_aliases_names == [

--- a/test/test_multiple_subqueries.py
+++ b/test/test_multiple_subqueries.py
@@ -399,3 +399,30 @@ def test_resolving_columns_in_sub_queries_functions():
         "select": ["aa", "uu", "au", "bb", "price"],
     }
     assert parser.subqueries_names == ["sq"]
+
+
+def test_readme_query():
+    parser = Parser(
+        """
+        SELECT COUNT(1) FROM
+        (SELECT std.task_id FROM some_task_detail std WHERE std.STATUS = 1) a
+        JOIN (SELECT st.task_id FROM some_task st WHERE task_type_id = 80) b
+        ON a.task_id = b.task_id;
+        """
+    )
+    assert parser.subqueries == {
+        "a": "SELECT std.task_id FROM some_task_detail std WHERE std.STATUS = 1",
+        "b": "SELECT st.task_id FROM some_task st WHERE task_type_id = 80",
+    }
+    assert parser.subqueries_names == ["a", "b"]
+    assert parser.columns == [
+        "some_task_detail.task_id",
+        "some_task_detail.STATUS",
+        "some_task.task_id",
+        "task_type_id",
+    ]
+    assert parser.columns_dict == {
+        "join": ["some_task_detail.task_id", "some_task.task_id"],
+        "select": ["some_task_detail.task_id", "some_task.task_id"],
+        "where": ["some_task_detail.STATUS", "task_type_id"],
+    }

--- a/test/test_multiple_subqueries.py
+++ b/test/test_multiple_subqueries.py
@@ -72,38 +72,32 @@ from (
         "days_final_qry",
         "subdays",
     ]
+
+    assert parser.columns_aliases == {
+        "DAYS_OFFER1": ["RowNo", "days_to_offer"],
+        "DAYS_OFFER2": ["RowNo", "days_to_offer"],
+        "DAYS_OFFER3": ["RowNo", "days_to_offer"],
+        "days_to_offer": [
+            "job_request_offer.first_presented_date",
+            "job_request.creation_date",
+        ],
+        "IS_INTERVIEW": "job_request_offer.first_interview_scheduled_date",
+        "IS_PRESENTATION": "job_request_offer.first_presented_date",
+        "InitialChangeDate": "job_request_offer.first_presented_date",
+        "LIFETIME": ["lifecycle.creation_date", "job_request.creation_date"],
+        "NUM_APPLICATIONS": [
+            "job_request_application.application_source",
+            "job_request_application.id",
+        ],
+        "NUM_CANDIDATES": "job_request_application.id",
+        "NUM_CONTRACTED": "job_request_offer.stage",
+        "NUM_INTERVIEWED": "IS_INTERVIEW",
+        "NUM_OFFERED": "IS_PRESENTATION",
+        "PROJECT_ID": "job_request.id",
+        "RowNo": "job_request_offer.job_request_application_id",
+    }
+
     assert parser.columns == [
-        "main_qry.*",
-        "subdays.DAYS_OFFER1",  # subquery nested resolve?
-        "subdays.DAYS_OFFER2",  # subquery nested resolve?
-        "subdays.DAYS_OFFER3",  # subquery nested resolve?
-        "job_request.id",
-        "lifecycle.creation_date",
-        "job_request.creation_date",
-        "job_request_application.application_source",
-        "job_request_application.id",
-        "job_request_offer.stage",
-        "job_request_application.job_request_id",
-        "job_request_offer.job_request_application_id",
-        "lifecycle.object_id",
-        "lifecycle.lifecycle_object_type",
-        "lifecycle.event",
-        "job_request_offer.first_interview_scheduled_date",
-        "job_request_offer.first_presented_date",
-        "jrah2.job_request_application_id",  # subquery nested resolve?
-        "job_request.client_id",
-        "client.id",
-        "job_request.from_point_break",
-        "client.name",
-        "presentation.id",
-        "presentation_job_request_offer.presentation_id",
-        "presentation_job_request_offer.job_request_offer_id",
-        "job_request_offer.id",
-        "presentation.job_request_id",
-        "subdays.PROJECT_ID",  # subquery nested resolve?
-        "main_qry.PROJECT_ID",  # subquery nested resolve?
-    ]
-    assert parser.columns_without_subqueries == [
         "job_request.id",
         "lifecycle.creation_date",
         "job_request.creation_date",
@@ -244,8 +238,6 @@ task_type_id = 80
         "some_task_detail.STATUS",
         "some_task.task_id",
         "task_type_id",
-        "a.new_task_id",
-        "b.task_id",
     ]
     assert parser.columns_without_subqueries == [
         "some_task_detail.task_id",
@@ -254,7 +246,7 @@ task_type_id = 80
         "task_type_id",
     ]
     assert parser.columns_dict == {
-        "join": ["a.new_task_id", "b.task_id"],
+        "join": ["some_task_detail.task_id", "some_task.task_id"],
         "select": ["some_task_detail.task_id", "some_task.task_id"],
         "where": ["some_task_detail.STATUS", "task_type_id"],
     }


### PR DESCRIPTION
Final piece of work in regard of resolving aliases and columns coming from sub-queries to the actual database columns.
Now all aliases should resolve and only real columns should be included in columns and columns_dict.

Following the updated readme note the tables in join:
```python
from sql_metadata import Parser

parser = Parser(
"""
SELECT COUNT(1) FROM
(SELECT std.task_id FROM some_task_detail std WHERE std.STATUS = 1) a
JOIN (SELECT st.task_id FROM some_task st WHERE task_type_id = 80) b
ON a.task_id = b.task_id;
"""
)

# get sub-queries dictionary
parser.subqueries
# {"a": "SELECT std.task_id FROM some_task_detail std WHERE std.STATUS = 1",
#  "b": "SELECT st.task_id FROM some_task st WHERE task_type_id = 80"}


# get names/ aliases of sub-queries / derived tables
parser.subqueries_names
# ["a", "b"]

# note that columns coming from sub-queries are resolved to real columns
parser.columns
#["some_task_detail.task_id", "some_task_detail.STATUS", "some_task.task_id", 
# "task_type_id"]

# same applies for columns_dict, note the join columns are resolved
parser.columns_dict
#{'join': ['some_task_detail.task_id', 'some_task.task_id'],
# 'select': ['some_task_detail.task_id', 'some_task.task_id'],
# 'where': ['some_task_detail.STATUS', 'task_type_id']}

```

Let me know what you think :)