### PR TITLE
Multi from aliases

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+max-complexity = 8

--- a/poetry.lock
+++ b/poetry.lock
@@ -146,6 +146,20 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "flake8"
+version = "3.9.2"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.7.0,<2.8.0"
+pyflakes = ">=2.3.0,<2.4.0"
+
+[[package]]
 name = "idna"
 version = "2.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -251,6 +265,22 @@ dev = ["pre-commit", "tox"]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.7.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.3.1"
+description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -410,7 +440,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "13ff6b2d94c6f1917eabc79d1bd141221c70dd2b4d8c6a39bada187be9da8bb5"
+content-hash = "bc945c1c1cf3b94faad50c6ccd71985ffdf136cf323bfb79608cea9c74b258da"
 
 [metadata.files]
 appdirs = [
@@ -514,6 +544,10 @@ dataclasses = [
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
+flake8 = [
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
@@ -576,6 +610,14 @@ pluggy = [
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
+    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
+pyflakes = [
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pylint = [
     {file = "pylint-2.9.3-py3-none-any.whl", hash = "sha256:5d46330e6b8886c31b5e3aba5ff48c10f4aa5e76cbf9002c6544306221e63fbc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pylint = "^2.9.3"
 pytest = "^6.2.4"
 pytest-cov = "^2.12.1"
 coveralls = "^3.1.0"
+flake8 = "^3.9.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/sql_metadata/__init__.py
+++ b/sql_metadata/__init__.py
@@ -1,5 +1,6 @@
 """
-Module for parsing sql queries and returning columns, tables, names of with statements etc.
+Module for parsing sql queries and returning columns,
+tables, names of with statements etc.
 """
 # pylint:disable=unsubscriptable-object
 from sql_metadata.parser import Parser

--- a/sql_metadata/compat.py
+++ b/sql_metadata/compat.py
@@ -1,5 +1,6 @@
 """
-This module provides a temporary compatibility layer for legacy API dating back to 1.x version.
+This module provides a temporary compatibility layer
+for legacy API dating back to 1.x version.
 
 Change your old imports:
 

--- a/sql_metadata/generalizator.py
+++ b/sql_metadata/generalizator.py
@@ -53,7 +53,8 @@ class Generalizator:
     @property
     def generalize(self) -> str:
         """
-        Removes most variables from an SQL query and replaces them with X or N for numbers.
+        Removes most variables from an SQL query
+        and replaces them with X or N for numbers.
 
         Based on Mediawiki's DatabaseBase::generalizeSQL
         """

--- a/sql_metadata/keywords_lists.py
+++ b/sql_metadata/keywords_lists.py
@@ -77,6 +77,7 @@ class TokenType(str, Enum):
     TABLE_ALIAS = "TABLE_ALIAS"
     WITH_NAME = "WITH_NAME"
     SUB_QUERY_NAME = "SUB_QUERY_NAME"
+    PARENTHESIS = "PARENTHESIS"
 
 
 # cannot fully replace with enum as with/select has the same key

--- a/sql_metadata/keywords_lists.py
+++ b/sql_metadata/keywords_lists.py
@@ -66,14 +66,15 @@ class QueryType(str, Enum):
     ALTER = "ALTER TABLE"
 
 
-class TokenTypes(str, Enum):
+class TokenType(str, Enum):
     """
     Types of SQLTokens
     """
 
     COLUMN = "COLUMN"
     TABLE = "TABLE"
-    ALIAS = "ALIAS"
+    COLUMN_ALIAS = "COLUMN_ALIAS"
+    TABLE_ALIAS = "TABLE_ALIAS"
     WITH_NAME = "WITH_NAME"
     SUB_QUERY_NAME = "SUB_QUERY_NAME"
 

--- a/sql_metadata/keywords_lists.py
+++ b/sql_metadata/keywords_lists.py
@@ -66,6 +66,18 @@ class QueryType(str, Enum):
     ALTER = "ALTER TABLE"
 
 
+class TokenTypes(str, Enum):
+    """
+    Types of SQLTokens
+    """
+
+    COLUMN = "COLUMN"
+    TABLE = "TABLE"
+    ALIAS = "ALIAS"
+    WITH_NAME = "WITH_NAME"
+    SUB_QUERY_NAME = "SUB_QUERY_NAME"
+
+
 # cannot fully replace with enum as with/select has the same key
 SUPPORTED_QUERY_TYPES = {
     "INSERT": QueryType.INSERT,

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -260,6 +260,7 @@ class Parser:  # pylint: disable=R0902
                             self._add_to_columns_aliases_subsection(
                                 token=token, left_expand=False
                             )
+                            token.token_type = TokenType.COLUMN_ALIAS
                             continue
                         column = self._resolve_sub_queries(column)
                         self._add_to_columns_with_tables(token, column)
@@ -280,8 +281,6 @@ class Parser:  # pylint: disable=R0902
                     )
                     token.token_type = TokenType.COLUMN
                     columns.append(column)
-                # elif token.value in self.columns_aliases_names:
-                #     self._add_to_columns_aliases_subsection(token=token)
             elif (
                 token.is_wildcard
                 and token.last_keyword_normalized == "SELECT"
@@ -707,6 +706,7 @@ class Parser:  # pylint: disable=R0902
                 token.previous_token.normalized == "AS"
                 and token.get_nth_previous(2).is_subquery_end
             ):
+                token.token_type = TokenType.SUB_QUERY_NAME
                 subqueries_names.append(str(token))
 
         self._subqueries_names = subqueries_names

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -230,7 +230,7 @@ class Parser:  # pylint: disable=R0902
                     continue
 
                 # we're in CREATE TABLE query with the columns
-                # ignore any annotations outside the parenthesis with the list of columns
+                # ignore annotations outside the parenthesis with the list of columns
                 # e.g. ) CHARACTER SET utf8;
                 if (
                     not token.is_in_parenthesis

--- a/test/test_aliases.py
+++ b/test/test_aliases.py
@@ -13,7 +13,8 @@ def test_get_query_table_aliases():
         Parser("SELECT e.foo FROM (SELECT * FROM bar) AS e").tables_aliases == {}
     ), "Sub-query aliases are ignored"
     assert Parser(
-        "SELECT a.* FROM product_a AS a JOIN product_b AS b ON a.ip_address = b.ip_address"
+        "SELECT a.* FROM product_a AS a "
+        "JOIN product_b AS b ON a.ip_address = b.ip_address"
     ).tables_aliases == {"a": "product_a", "b": "product_b"}
 
 

--- a/test/test_column_aliases.py
+++ b/test/test_column_aliases.py
@@ -6,9 +6,11 @@ def test_column_aliases_with_subquery():
     SELECT yearweek(SignDate) as                         Aggregation,
        BusinessSource,
        (SELECT sum(C2Count)
-        from (SELECT count(C2) as C2Count, BusinessSource, yearweek(Start1) Start1, yearweek(End1) End1
+        from (SELECT count(C2) as C2Count, BusinessSource,
+        yearweek(Start1) Start1, yearweek(End1) End1
               from (
-                       SELECT ContractID as C2, BusinessSource, StartDate as Start1, EndDate as End1
+                       SELECT ContractID as C2, BusinessSource, StartDate as Start1,
+                       EndDate as End1
                        from data_contracts_report
                    ) sq2
               group by 2, 3, 4) sq

--- a/test/test_comments.py
+++ b/test/test_comments.py
@@ -3,13 +3,16 @@ from sql_metadata import Parser
 
 def test_getting_comments():
     parser = Parser(
-        "INSERT /* VoteHelper::addVote xxx */  INTO `page_vote` (article_id,user_id,`time`) VALUES ('442001','27574631','20180228130846')"
+        "INSERT /* VoteHelper::addVote xxx */  "
+        "INTO `page_vote` (article_id,user_id,`time`) "
+        "VALUES ('442001','27574631','20180228130846')"
     )
     assert parser.comments == ["/* VoteHelper::addVote xxx */"]
 
     parser = Parser(
         "SELECT /* CategoryPaginationViewer::processSection */  "
-        "page_namespace,page_title,page_len,page_is_redirect,cl_sortkey_prefix  FROM `page` "
+        "page_namespace,page_title,page_len,page_is_redirect,cl_sortkey_prefix  "
+        "FROM `page` "
         "INNER JOIN `categorylinks` FORCE INDEX (cl_sortkey) ON ((cl_from = page_id))  "
         " /* We should add more conditions */ "
         "WHERE cl_type = 'page' AND cl_to = 'Spotify/Song'  "

--- a/test/test_create_table.py
+++ b/test/test_create_table.py
@@ -49,7 +49,7 @@ def test_simple_create_table_as_select():
 
 def test_create_table_as_select_with_joins():
     qry = """
-        CREATE table xyz as 
+        CREATE table xyz as
         SELECT *
         from table_a
         join table_b on (table_a.name = table_b.name)
@@ -70,7 +70,7 @@ def test_create_table_as_select_with_joins():
 
 def test_creating_table_as_select_with_with_clause():
     qry = """
-        CREATE table xyz as 
+        CREATE table xyz as
         with sub as (select it_id from internal_table)
         SELECT *
         from table_a
@@ -109,7 +109,7 @@ def test_creating_table_as_select_with_with_clause():
 
 def test_create_table_as_select_in_parentheses():
     qry = """
-        CREATE TABLE records AS 
+        CREATE TABLE records AS
         (SELECT t.id, t.name, e.name as energy FROM t JOIN e ON t.e_id = e.id)
         """
     parser = Parser(qry)
@@ -133,7 +133,7 @@ def test_create_table_with_schema_name():
 
 def test_create_table_as_select_in_parentheses_with_schema():
     qry = """
-        CREATE TABLE mysuper_secret_schema.records AS 
+        CREATE TABLE mysuper_secret_schema.records AS
         (SELECT t.id, t.name, e.name as energy FROM t JOIN e ON t.e_id = e.id)
         """
     parser = Parser(qry)

--- a/test/test_getting_columns.py
+++ b/test/test_getting_columns.py
@@ -402,3 +402,9 @@ def test_columns_with_aliases_same_as_columns():
         "clicks": ["clicks", "seventotalunits"],
         "cpc": ["clicks", "spend"],
     }
+
+
+def test_columns_with_distinct():
+    query = "SELECT DISTINCT customer_id FROM table"
+    parsed = Parser(query)
+    assert parsed.columns == ["customer_id"]

--- a/test/test_getting_columns.py
+++ b/test/test_getting_columns.py
@@ -15,7 +15,8 @@ def test_cast_and_convert_functions():
 
 def test_queries_with_null_conditions():
     parser = Parser(
-        "SELECT id FROM cm WHERE cm.status = 1 AND cm.OPERATIONDATE IS NULL AND cm.OID IN(123123);"
+        "SELECT id FROM cm WHERE cm.status = 1 AND cm.OPERATIONDATE IS NULL "
+        "AND cm.OID IN(123123);"
     )
     assert parser.columns == ["id", "cm.status", "cm.OPERATIONDATE", "cm.OID"]
     assert parser.columns_dict == {
@@ -24,7 +25,8 @@ def test_queries_with_null_conditions():
     }
 
     parser = Parser(
-        "SELECT id FROM cm WHERE cm.status = 1 AND cm.OPERATIONDATE IS NOT NULL AND cm.OID IN(123123);"
+        "SELECT id FROM cm WHERE cm.status = 1 AND cm.OPERATIONDATE IS NOT NULL "
+        "AND cm.OID IN(123123);"
     )
     assert parser.columns == ["id", "cm.status", "cm.OPERATIONDATE", "cm.OID"]
     assert parser.columns_dict == {
@@ -40,7 +42,7 @@ def test_queries_with_distinct():
 
 
 def test_joins():
-    assert ["page_title", "rd_title", "rd_namespace", "page_id", "rd_from",] == Parser(
+    assert ["page_title", "rd_title", "rd_namespace", "page_id", "rd_from"] == Parser(
         "SELECT  page_title  FROM `redirect` INNER JOIN `page` "
         "ON (rd_title = 'foo' AND rd_namespace = '100' AND (page_id = rd_from))"
     ).columns
@@ -106,7 +108,8 @@ def test_update_and_replace():
 
     # REPLACE queries
     parser = Parser(
-        "REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) VALUES ('47','infoboxes','')"
+        "REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) "
+        "VALUES ('47','infoboxes','')"
     )
     assert parser.query_type == QueryType.REPLACE
     assert parser.columns == ["pp_page", "pp_propname", "pp_value"]
@@ -116,14 +119,18 @@ def test_update_and_replace():
 def test_complex_queries_columns():
     # @see https://github.com/macbre/sql-metadata/issues/6
     assert Parser(
-        "SELECT 1 as c    FROM foo_pageviews WHERE time_id = '2018-01-07 00:00:00' AND period_id = '2' LIMIT 1"
+        "SELECT 1 as c    FROM foo_pageviews WHERE time_id = '2018-01-07 00:00:00' "
+        "AND period_id = '2' LIMIT 1"
     ).columns == ["time_id", "period_id"]
 
     # table aliases
     parser = Parser(
-        "SELECT r.wiki_id AS id, pageviews_7day AS pageviews FROM report_wiki_recent_pageviews AS r "
-        "INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id WHERE d.is_public = '1' "
-        "AND r.lang IN ( 'en', 'ru' ) AND r.hub_name = 'gaming' ORDER BY pageviews DESC LIMIT 300"
+        "SELECT r.wiki_id AS id, pageviews_7day AS pageviews "
+        "FROM report_wiki_recent_pageviews AS r "
+        "INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id "
+        "WHERE d.is_public = '1' "
+        "AND r.lang IN ( 'en', 'ru' ) AND r.hub_name = 'gaming' "
+        "ORDER BY pageviews DESC LIMIT 300"
     )
     assert parser.columns_aliases_names == ["id", "pageviews"]
     assert parser.columns_aliases == {
@@ -162,7 +169,8 @@ def test_complex_queries_columns():
         "SELECT  count(fw1.wiki_id) as wam_results_total  FROM `fact_wam_scores` `fw1` "
         "left join `fact_wam_scores` `fw2` ON ((fw1.wiki_id = fw2.wiki_id) AND "
         "(fw2.time_id = FROM_UNIXTIME(1466380800))) left join `dimension_wikis` `dw` "
-        "ON ((fw1.wiki_id = dw.wiki_id))  WHERE (fw1.time_id = FROM_UNIXTIME(1466467200)) "
+        "ON ((fw1.wiki_id = dw.wiki_id))  "
+        "WHERE (fw1.time_id = FROM_UNIXTIME(1466467200)) "
         "AND (dw.url like '%%' OR dw.title like '%%') AND fw1.vertical_id IN "
         "('0','1','2','3','4','5','6','7')  AND (fw1.wiki_id NOT "
         "IN ('23312','70256','168929','463633','381622','1089624')) "
@@ -200,14 +208,17 @@ def test_complex_queries_columns():
 
 def test_columns_with_comments():
     parser = Parser(
-        "INSERT /* VoteHelper::addVote xxx */  INTO `page_vote` (article_id,user_id,`time`) VALUES ('442001','27574631','20180228130846')"
+        "INSERT /* VoteHelper::addVote xxx */  "
+        "INTO `page_vote` (article_id,user_id,`time`) "
+        "VALUES ('442001','27574631','20180228130846')"
     )
     assert parser.query_type == QueryType.INSERT
     assert parser.columns == ["article_id", "user_id", "time"]
 
     # REPLACE queries
     parser = Parser(
-        "REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) VALUES ('47','infoboxes','')"
+        "REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) "
+        "VALUES ('47','infoboxes','')"
     )
     assert parser.query_type == QueryType.REPLACE
     assert parser.columns == ["pp_page", "pp_propname", "pp_value"]
@@ -215,7 +226,8 @@ def test_columns_with_comments():
 
     assert Parser(
         "SELECT /* CategoryPaginationViewer::processSection */  "
-        "page_namespace,page_title,page_len,page_is_redirect,cl_sortkey_prefix  FROM `page` "
+        "page_namespace,page_title,page_len,page_is_redirect,cl_sortkey_prefix  "
+        "FROM `page` "
         "INNER JOIN `categorylinks` FORCE INDEX (cl_sortkey) ON ((cl_from = page_id))  "
         "WHERE cl_type = 'page' AND cl_to = 'Spotify/Song'  "
         "ORDER BY cl_sortkey LIMIT 927600,200"
@@ -235,7 +247,12 @@ def test_columns_with_comments():
 
 def test_columns_with_keyword_aliases():
     parser = Parser(
-        "SELECT date_format(time_id,'%Y-%m-%d') AS date, pageviews AS cnt         FROM rollup_wiki_pageviews      WHERE period_id = '2'   AND wiki_id = '1676379'         AND time_id BETWEEN '2018-01-08'        AND '2018-01-01'"
+        "SELECT date_format(time_id,'%Y-%m-%d') AS date, pageviews AS cnt         "
+        "FROM rollup_wiki_pageviews      "
+        "WHERE period_id = '2'   "
+        "AND wiki_id = '1676379'         "
+        "AND time_id BETWEEN '2018-01-08'        "
+        "AND '2018-01-01'"
     )
     assert parser.columns == ["time_id", "pageviews", "period_id", "wiki_id"]
     assert parser.columns_aliases_names == ["date", "cnt"]
@@ -252,14 +269,15 @@ def test_columns_and_sql_functions():
     ]
     assert Parser("SELECT avg(col)+sum(col2) from dual").columns == ["col", "col2"]
     assert Parser(
-        "SELECT count(col)+max(col2)+ min(col3)+ count(distinct  col4) + custom_func(col5) from dual"
+        "SELECT count(col)+max(col2)+ min(col3)+ count(distinct  col4) + "
+        "custom_func(col5) from dual"
     ).columns == ["col", "col2", "col3", "col4", "col5"]
 
 
 def test_columns_starting_with_keywords():
     query = """
-    SELECT `schema_name`, full_table_name, `column_name`, `catalog_name`, 
-    `table_name`, column_length, column_weight, annotation 
+    SELECT `schema_name`, full_table_name, `column_name`, `catalog_name`,
+    `table_name`, column_length, column_weight, annotation
     FROM corporate.all_tables
     """
     parser = Parser(query)
@@ -277,8 +295,8 @@ def test_columns_starting_with_keywords():
 
 def test_columns_as_unquoted_keywords():
     query = """
-    SELECT schema_name, full_table_name, column_name, catalog_name, 
-    table_name, column_length, column_weight, annotation 
+    SELECT schema_name, full_table_name, column_name, catalog_name,
+    table_name, column_length, column_weight, annotation
     FROM corporate.all_tables
     """
     parser = Parser(query)
@@ -310,25 +328,25 @@ def test_columns_with_keywords_parts():
 
 def test_columns_with_complex_aliases_same_as_columns():
     query = """
-    SELECT targetingtype, sellerid, sguid, 'd01' as datetype, adgroupname, targeting, 
-    customersearchterm, 
-    'product_search_term' as `type`, 
-    sum(impressions) as impr, 
-    sum(clicks) as clicks, 
-    sum(seventotalunits) as sold, 
-    sum(sevenadvertisedskuunits) as advertisedskuunits, 
-    sum(sevenotherskuunits) as otherskuunits, 
-    sum(sevendaytotalsales) as totalsales, 
-    round(sum(spend), 4) as spend, if(sum(impressions) > 0, 
-    round(sum(clicks)/sum(impressions), 4), 0) as ctr, 
-    if(sum(clicks) > 0, round(sum(seventotalunits)/sum(clicks), 4), 0) as cr, 
-    if(sum(clicks) > 0, round(sum(spend)/sum(clicks), 2), 0) as cpc 
-    from amazon_pl.search_term_report_impala 
-    where reportday >= to_date('2021-05-16 00:00:00.0') 
-    and reportday <= to_date('2021-05-16 00:00:00.0') 
-    and targetingtype in ('auto','manual') 
-    and sguid is not null and sguid != '' 
-    group by targetingtype,sellerid,sguid,adgroupname,targeting,customersearchterm 
+    SELECT targetingtype, sellerid, sguid, 'd01' as datetype, adgroupname, targeting,
+    customersearchterm,
+    'product_search_term' as `type`,
+    sum(impressions) as impr,
+    sum(clicks) as clicks,
+    sum(seventotalunits) as sold,
+    sum(sevenadvertisedskuunits) as advertisedskuunits,
+    sum(sevenotherskuunits) as otherskuunits,
+    sum(sevendaytotalsales) as totalsales,
+    round(sum(spend), 4) as spend, if(sum(impressions) > 0,
+    round(sum(clicks)/sum(impressions), 4), 0) as ctr,
+    if(sum(clicks) > 0, round(sum(seventotalunits)/sum(clicks), 4), 0) as cr,
+    if(sum(clicks) > 0, round(sum(spend)/sum(clicks), 2), 0) as cpc
+    from amazon_pl.search_term_report_impala
+    where reportday >= to_date('2021-05-16 00:00:00.0')
+    and reportday <= to_date('2021-05-16 00:00:00.0')
+    and targetingtype in ('auto','manual')
+    and sguid is not null and sguid != ''
+    group by targetingtype,sellerid,sguid,adgroupname,targeting,customersearchterm
     order by impr desc
     """
     parser = Parser(query)
@@ -353,11 +371,11 @@ def test_columns_with_complex_aliases_same_as_columns():
 def test_columns_aliases_as_unqoted_keywords():
     query = """
     SELECT
-    product_search_term as type, 
-    sum(clicks) as clicks, 
-    sum(seventotalunits) as schema_name, 
+    product_search_term as type,
+    sum(clicks) as clicks,
+    sum(seventotalunits) as schema_name,
     sum(sevenadvertisedskuunits) as advertisedskuunits
-    from amazon_pl.search_term_report_impala 
+    from amazon_pl.search_term_report_impala
     """
     parser = Parser(query)
     assert parser.columns == [
@@ -381,10 +399,10 @@ def test_columns_aliases_as_unqoted_keywords():
 
 def test_columns_with_aliases_same_as_columns():
     query = """
-    SELECT 
-    round(sum(impressions),1) as impressions, 
+    SELECT
+    round(sum(impressions),1) as impressions,
     sum(clicks) as clicks
-    from amazon_pl.search_term_report_impala 
+    from amazon_pl.search_term_report_impala
     """
     parser = Parser(query)
     assert parser.columns == ["impressions", "clicks"]
@@ -392,9 +410,9 @@ def test_columns_with_aliases_same_as_columns():
 
     query = """
     SELECT
-    if(sum(clicks) > 0, round(sum(seventotalunits)/sum(clicks), 4), 0) as clicks, 
-    if(sum(clicks) > 0, round(sum(spend)/sum(clicks), 2), 0) as cpc 
-    from amazon_pl.search_term_report_impala 
+    if(sum(clicks) > 0, round(sum(seventotalunits)/sum(clicks), 4), 0) as clicks,
+    if(sum(clicks) > 0, round(sum(spend)/sum(clicks), 2), 0) as cpc
+    from amazon_pl.search_term_report_impala
     """
     parser = Parser(query)
     assert parser.columns == ["clicks", "seventotalunits", "spend"]

--- a/test/test_getting_tables.py
+++ b/test/test_getting_tables.py
@@ -493,7 +493,7 @@ def test_get_tables_with_leading_digits():
         "SELECT t.val as value, count(*) FROM `0020_big_table`"
     ).tables
     assert ["0020_big_table"] == Parser(
-        'SELECT t.val as value, count(*) '
+        "SELECT t.val as value, count(*) "
         'FROM "0020_big_table" as t WHERE id BETWEEN 10 AND 20 GROUP BY val'
     ).tables
     assert ["0020_big_table"] == Parser(

--- a/test/test_getting_tables.py
+++ b/test/test_getting_tables.py
@@ -19,11 +19,19 @@ def test_simple_queries_tables():
     ).tables
 
     assert ["revision", "page", "wikicities_user"] == Parser(
-        "SELECT rev_id,rev_page,rev_text_id,rev_timestamp,rev_comment,rev_user_text,rev_user,rev_minor_edit,rev_deleted,rev_len,rev_parent_id,rev_shaN,page_namespace,page_title,page_id,page_latest,user_name FROM `revision` INNER JOIN `page` ON ((page_id = rev_page)) LEFT JOIN `wikicities_user` ON ((rev_user != N) AND (user_id = rev_user)) WHERE rev_id = X LIMIT N"
+        "SELECT rev_id,rev_page,rev_text_id,rev_timestamp,rev_comment,rev_user_text,"
+        "rev_user,rev_minor_edit,rev_deleted,rev_len,rev_parent_id,rev_shaN,"
+        "page_namespace,page_title,page_id,page_latest,user_name "
+        "FROM `revision` INNER JOIN `page` ON ((page_id = rev_page)) "
+        "LEFT JOIN `wikicities_user` ON ((rev_user != N) AND (user_id = rev_user)) "
+        "WHERE rev_id = X LIMIT N"
     ).tables
 
     assert ["events"] == Parser(
-        "SELECT COUNT( 0 ) AS cnt, date_format(event_date, '%Y-%m-%d') AS date 	 FROM events 	 WHERE event_date BETWEEN '2017-10-18 00:00:00' 	 AND '2017-10-24 23:59:59'  	 AND wiki_id = '1289985' GROUP BY date WITH ROLLUP"
+        "SELECT COUNT( 0 ) AS cnt, date_format(event_date, '%Y-%m-%d') AS date 	 "
+        "FROM events 	 WHERE event_date BETWEEN '2017-10-18 00:00:00' 	 "
+        "AND '2017-10-24 23:59:59'  	 "
+        "AND wiki_id = '1289985' GROUP BY date WITH ROLLUP"
     ).tables
 
 
@@ -31,36 +39,59 @@ def test_complex_query_tables():
     # complex queries
     # @see https://github.com/macbre/query-digest/issues/16
     assert ["report_wiki_recent_pageviews", "dimension_wikis"] == Parser(
-        "SELECT r.wiki_id AS id, pageviews_Nday AS pageviews FROM report_wiki_recent_pageviews AS r INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id WHERE d.public = X AND r.lang = X AND r.hub_name = X ORDER BY pageviews DESC LIMIT N"
+        "SELECT r.wiki_id AS id, pageviews_Nday AS pageviews "
+        "FROM report_wiki_recent_pageviews AS r "
+        "INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id "
+        "WHERE d.public = X AND r.lang = X AND r.hub_name = X "
+        "ORDER BY pageviews DESC LIMIT N"
     ).tables
 
     assert ["dimension_wikis", "fact_wam_scores"] == Parser(
-        "SELECT DISTINCT dw.lang FROM `dimension_wikis` `dw` INNER JOIN `fact_wam_scores` `fwN` ON ((dw.wiki_id = fwN.wiki_id)) WHERE fwN.time_id = FROM_UNIXTIME(N) ORDER BY dw.lang ASC"
+        "SELECT DISTINCT dw.lang FROM `dimension_wikis` `dw` "
+        "INNER JOIN `fact_wam_scores` `fwN` ON ((dw.wiki_id = fwN.wiki_id)) "
+        "WHERE fwN.time_id = FROM_UNIXTIME(N) ORDER BY dw.lang ASC"
     ).tables
 
     assert ["fact_wam_scores", "dimension_wikis"] == Parser(
-        "SELECT count(fwN.wiki_id) as wam_results_total FROM `fact_wam_scores` `fwN` left join `fact_wam_scores` `fwN` ON ((fwN.wiki_id = fwN.wiki_id) AND (fwN.time_id = FROM_UNIXTIME(N))) left join `dimension_wikis` `dw` ON ((fwN.wiki_id = dw.wiki_id)) WHERE (fwN.time_id = FROM_UNIXTIME(N)) AND (dw.url like X OR dw.title like X) AND fwN.vertical_id IN (XYZ) AND dw.lang = X AND (fwN.wiki_id NOT IN (XYZ)) AND ((dw.url IS NOT NULL AND dw.title IS NOT NULL))"
+        "SELECT count(fwN.wiki_id) as wam_results_total FROM `fact_wam_scores` `fwN` "
+        "left join `fact_wam_scores` `fwN` ON ((fwN.wiki_id = fwN.wiki_id) "
+        "AND (fwN.time_id = FROM_UNIXTIME(N))) "
+        "left join `dimension_wikis` `dw` ON ((fwN.wiki_id = dw.wiki_id)) "
+        "WHERE (fwN.time_id = FROM_UNIXTIME(N)) AND (dw.url like X OR dw.title like X) "
+        "AND fwN.vertical_id IN (XYZ) AND dw.lang = X AND (fwN.wiki_id NOT IN (XYZ)) "
+        "AND ((dw.url IS NOT NULL AND dw.title IS NOT NULL))"
     ).tables
 
     assert ["revision", "page", "wikicities_cN.user"] == Parser(
-        "SELECT rev_id,rev_page,rev_text_id,rev_timestamp,rev_comment,rev_user_text,rev_user,rev_minor_edit,rev_deleted,rev_len,rev_parent_id,rev_shaN,page_namespace,page_title,page_id,page_latest,user_name FROM `revision` INNER JOIN `page` ON ((page_id = rev_page)) LEFT JOIN `wikicities_cN`.`user` ON ((rev_user != N) AND (user_id = rev_user)) WHERE rev_id = X LIMIT N"
+        "SELECT rev_id,rev_page,rev_text_id,rev_timestamp,rev_comment,rev_user_text,"
+        "rev_user,rev_minor_edit,rev_deleted,rev_len,rev_parent_id,rev_shaN,"
+        "page_namespace,page_title,page_id,page_latest,user_name "
+        "FROM `revision` INNER JOIN `page` ON ((page_id = rev_page)) "
+        "LEFT JOIN `wikicities_cN`.`user` ON ((rev_user != N) "
+        "AND (user_id = rev_user)) WHERE rev_id = X LIMIT N"
     ).tables
 
     # complex queries, take two
     # @see https://github.com/macbre/sql-metadata/issues/6
     assert ["foo_pageviews"] == Parser(
-        "SELECT 1 as c    FROM foo_pageviews      WHERE time_id = '2018-01-07 00:00:00'   AND period_id = '2' LIMIT 1"
+        "SELECT 1 as c    FROM foo_pageviews      "
+        "WHERE time_id = '2018-01-07 00:00:00'   AND period_id = '2' LIMIT 1"
     ).tables
 
     # table aliases
     assert ["report_wiki_recent_pageviews", "dimension_wikis"] == Parser(
-        "SELECT r.wiki_id AS id, pageviews_7day AS pageviews FROM report_wiki_recent_pageviews AS r INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id WHERE d.public = '1' AND r.lang IN ( 'en', 'ru' ) AND r.hub_name = 'gaming' ORDER BY pageviews DESC LIMIT 300"
+        "SELECT r.wiki_id AS id, pageviews_7day AS pageviews "
+        "FROM report_wiki_recent_pageviews AS r "
+        "INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id "
+        "WHERE d.public = '1' AND r.lang IN ( 'en', 'ru' ) "
+        "AND r.hub_name = 'gaming' ORDER BY pageviews DESC LIMIT 300"
     ).tables
 
     # include multiple FROM tables when they prefixed
     # @see https://github.com/macbre/sql-metadata/issues/38
     assert ["MYDB1.TABLE1", "MYDB2.TABLE2"] == Parser(
-        "SELECT A.FIELD1, B.FIELD1, (A.FIELD1 * B.FIELD1) AS QTY FROM MYDB1.TABLE1 AS A, MYDB2.TABLE2 AS B"
+        "SELECT A.FIELD1, B.FIELD1, (A.FIELD1 * B.FIELD1) AS QTY "
+        "FROM MYDB1.TABLE1 AS A, MYDB2.TABLE2 AS B"
     ).tables
 
     # test whitespaces in keywords
@@ -68,7 +99,8 @@ def test_complex_query_tables():
     assert (
         ["tab", "tab2"]
         == Parser(
-            """SELECT a,b,c from tab full  outer \r\n\t  join tab2  on (col1 = col2) group   
+            """SELECT a,b,c from tab
+            full  outer \r\n\t  join tab2  on (col1 = col2) group
 \r\n   \t   by  a, b, c """
         ).tables
     )
@@ -77,16 +109,34 @@ def test_complex_query_tables():
 def test_joins():
     # self joins
     assert ["fact_wam_scores", "dimension_wikis"] == Parser(
-        "SELECT  count(fw1.wiki_id) as wam_results_total  FROM `fact_wam_scores` `fw1` left join `fact_wam_scores` `fw2` ON ((fw1.wiki_id = fw2.wiki_id) AND (fw2.time_id = FROM_UNIXTIME(1466380800))) left join `dimension_wikis` `dw` ON ((fw1.wiki_id = dw.wiki_id))  WHERE (fw1.time_id = FROM_UNIXTIME(1466467200)) AND (dw.url like '%%' OR dw.title like '%%') AND fw1.vertical_id IN ('0','1','2','3','4','5','6','7')  AND (fw1.wiki_id NOT IN ('23312','70256','168929','463633','381622','524772','476782','9764','214934','170145','529622','52149','96420','390','468156','690804','197434','29197','88043','37317','466775','402313','169142','746246','119847','57268','1089624')) AND ((dw.url IS NOT NULL AND dw.title IS NOT NULL))"
+        "SELECT  count(fw1.wiki_id) as wam_results_total  "
+        "FROM `fact_wam_scores` `fw1` left join `fact_wam_scores` `fw2` "
+        "ON ((fw1.wiki_id = fw2.wiki_id) "
+        "AND (fw2.time_id = FROM_UNIXTIME(1466380800))) "
+        "left join `dimension_wikis` `dw` ON ((fw1.wiki_id = dw.wiki_id))  "
+        "WHERE (fw1.time_id = FROM_UNIXTIME(1466467200)) "
+        "AND (dw.url like '%%' OR dw.title like '%%') "
+        "AND fw1.vertical_id IN ('0','1','2','3','4','5','6','7')  "
+        "AND (fw1.wiki_id NOT IN ('23312','70256','168929','463633','381622','524772',"
+        "'476782','9764','214934','170145','529622','52149','96420','390','468156',"
+        "'690804','197434','29197','88043','37317','466775','402313','169142','746246',"
+        "'119847','57268','1089624')) "
+        "AND ((dw.url IS NOT NULL AND dw.title IS NOT NULL))"
     ).tables
 
     assert ["rollup_wiki_pageviews"] == Parser(
-        "SELECT date_format(time_id,'%Y-%m-%d') AS date, pageviews AS cnt         FROM rollup_wiki_pageviews      WHERE period_id = '2'   AND wiki_id = '1676379'         AND time_id BETWEEN '2018-01-08'        AND '2018-01-01'"
+        "SELECT date_format(time_id,'%Y-%m-%d') AS date, pageviews AS cnt         "
+        "FROM rollup_wiki_pageviews      "
+        "WHERE period_id = '2'   "
+        "AND wiki_id = '1676379'         "
+        "AND time_id BETWEEN '2018-01-08'        "
+        "AND '2018-01-01'"
     ).tables
 
     # JOINs
     assert ["product_a.users", "product_b.users"] == Parser(
-        "SELECT a.* FROM product_a.users AS a JOIN product_b.users AS b ON a.ip_address = b.ip_address"
+        "SELECT a.* FROM product_a.users AS a "
+        "JOIN product_b.users AS b ON a.ip_address = b.ip_address"
     ).tables
 
     assert ["redirect", "page"] == Parser(
@@ -154,7 +204,8 @@ def test_update_and_replace():
 
     # REPLACE queries
     assert ["page_props"] == Parser(
-        "REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) VALUES ('47','infoboxes','')"
+        "REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) "
+        "VALUES ('47','infoboxes','')"
     ).tables
 
 
@@ -184,7 +235,8 @@ def test_three_part_qualified_names():
     ).tables
 
     assert ["MYDB1.MYSCHEMA1.MYTABLE1", "MYDB2.MYSCHEMA2.MYTABLE2"] == Parser(
-        "SELECT * FROM MYDB1.MYSCHEMA1.MYTABLE1 A LEFT JOIN MYDB2.MYSCHEMA2.MYTABLE2 B ON A.COL = B.COL"
+        "SELECT * FROM MYDB1.MYSCHEMA1.MYTABLE1 A "
+        "LEFT JOIN MYDB2.MYSCHEMA2.MYTABLE2 B ON A.COL = B.COL"
     ).tables
 
     assert ["MYDB1.MYSCHEMA1.MYTABLE1", "MYDB2.MYSCHEMA2.MYTABLE2"] == Parser(
@@ -205,7 +257,9 @@ def test_insert_queries():
     assert ["foo"] == Parser("INSERT INTO `foo` (id,text) VALUES (X,X)").tables
 
     assert ["page_vote"] == Parser(
-        "INSERT /* VoteHelper::addVote xxx */  INTO `page_vote` (article_id,user_id,time) VALUES ('442001','27574631','20180228130846')"
+        "INSERT /* VoteHelper::addVote xxx */  "
+        "INTO `page_vote` (article_id,user_id,time) "
+        "VALUES ('442001','27574631','20180228130846')"
     ).tables
 
 
@@ -234,9 +288,10 @@ def test_table_name_with_group_by():
     assert (
         Parser(
             """
-                        SELECT s.cust_id,count(s.cust_id) FROM SH.sales s
-                        GROUP BY s.cust_id HAVING s.cust_id != '1660' AND s.cust_id != '2'
-                            """.strip()
+            SELECT s.cust_id,count(s.cust_id) FROM SH.sales s
+            GROUP BY s.cust_id HAVING s.cust_id != '1660'
+            AND s.cust_id != '2'
+            """.strip()
         ).tables
         == expected_tables
     )
@@ -245,15 +300,18 @@ def test_table_name_with_group_by():
 def test_datasets():
     # see https://github.com/macbre/sql-metadata/issues/38
     assert Parser(
-        "SELECT A.FIELD1, B.FIELD1, (A.FIELD1 * B.FIELD1) AS QTY FROM TABLE1 AS A, TABLE2 AS B"
+        "SELECT A.FIELD1, B.FIELD1, (A.FIELD1 * B.FIELD1) AS QTY "
+        "FROM TABLE1 AS A, TABLE2 AS B"
     ).tables == ["TABLE1", "TABLE2"]
 
     assert Parser(
-        "SELECT A.FIELD1, B.FIELD1, (A.FIELD1 * B.FIELD1) AS QTY FROM DATASET1.TABLE1, DATASET2.TABLE2"
+        "SELECT A.FIELD1, B.FIELD1, (A.FIELD1 * B.FIELD1) AS QTY "
+        "FROM DATASET1.TABLE1, DATASET2.TABLE2"
     ).tables == ["DATASET1.TABLE1", "DATASET2.TABLE2"]
 
     assert Parser(
-        "SELECT A.FIELD1, B.FIELD1, (A.FIELD1 * B.FIELD1) AS QTY FROM DATASET1.TABLE1 AS A, DATASET2.TABLE2 AS B"
+        "SELECT A.FIELD1, B.FIELD1, (A.FIELD1 * B.FIELD1) AS QTY "
+        "FROM DATASET1.TABLE1 AS A, DATASET2.TABLE2 AS B"
     ).tables == ["DATASET1.TABLE1", "DATASET2.TABLE2"]
 
 
@@ -309,38 +367,38 @@ WHERE bar = '1') t
 
 def test_db2_query():
     query = """
-    SELECT ca.IDENTIFICATION_CODE identificationCode, 
-eo.KBO_NUMBER kboNumber, 
+    SELECT ca.IDENTIFICATION_CODE identificationCode,
+eo.KBO_NUMBER kboNumber,
 eo.PARTY_NAME,
-ca.total_guaranteed totale_borgtocht, 
-coalesce(sum(ae1.remainder),0) Saldo, 
-coalesce(sum(ae3.remainder),0) uitstel_van_betaling, 
-coalesce(sum(ae4.remainder),0) reservering_aangifte, 
+ca.total_guaranteed totale_borgtocht,
+coalesce(sum(ae1.remainder),0) Saldo,
+coalesce(sum(ae3.remainder),0) uitstel_van_betaling,
+coalesce(sum(ae4.remainder),0) reservering_aangifte,
 coalesce(sum(ae5.remainder),0) reservering_vergunning,
-coalesce(sum(ae6.remainder),0) zekerheid_douanevervoer, 
+coalesce(sum(ae6.remainder),0) zekerheid_douanevervoer,
 coalesce(sum(ae7.remainder),0) zekerheid_accijnsbeweging,
-coalesce(sum(ae8.remainder),0) FRCT 
-from CUSTOMER_ACCOUNT ca 
-inner join economic_operator eo on eo.id = ca.economic_operator_id 
-join contact_details cd on cd.id = ca.contact_details_id 
-left join ( ca1_remainder_total_guaranteed crtg 
+coalesce(sum(ae8.remainder),0) FRCT
+from CUSTOMER_ACCOUNT ca
+inner join economic_operator eo on eo.id = ca.economic_operator_id
+join contact_details cd on cd.id = ca.contact_details_id
+left join ( ca1_remainder_total_guaranteed crtg
 inner join accounting_entity ae1 on ae1.id = crtg.accounting_entity_id)
-on crtg.id = ca.ca1_id 
-left join (ca3_credit_account cca inner join accounting_entity ae3 on ae3.id = 
-cca.accounting_entity_id) on cca.id = ca.ca3_id 
-left join (ca4_reservations_declaration crd inner join accounting_entity ae4 on 
-ae4.id = crd.accounting_entity_id) on crd.id = ca.ca4_id 
-left join (ca5_reservations_permits crp inner join accounting_entity ae5 on ae5.id 
-= crp.accounting_entity_id) on crp.id = ca.ca5_id 
-left join (CA6_GUARANTEE_CUSTOMS_TRANSPORT gct inner join accounting_entity ae6 on 
-ae6.id = gct.accounting_entity_id) on gct.id = ca.ca6_id 
-left join (CA7_GUARANTEE_EXCISE_PRODUCTS gep inner join accounting_entity ae7 on 
-ae7.id = gep.accounting_entity_id) on gep.id = ca.ca7_id 
-left join (ca8_frct cf inner join ca8_frct_per_discharge cfpd on cfpd.CA8_ID = 
-cf.id inner join accounting_entity ae8 on ae8.id = cfpd.accounting_entity_id) on 
-cf.id = ca.ca8_id 
-group by eo.PARTY_NAME,eo.KBO_NUMBER, ca.IDENTIFICATION_CODE, ca.total_guaranteed 
-order by eo.KBO_NUMBER, ca.IDENTIFICATION_CODE 
+on crtg.id = ca.ca1_id
+left join (ca3_credit_account cca inner join accounting_entity ae3 on ae3.id =
+cca.accounting_entity_id) on cca.id = ca.ca3_id
+left join (ca4_reservations_declaration crd inner join accounting_entity ae4 on
+ae4.id = crd.accounting_entity_id) on crd.id = ca.ca4_id
+left join (ca5_reservations_permits crp inner join accounting_entity ae5 on ae5.id
+= crp.accounting_entity_id) on crp.id = ca.ca5_id
+left join (CA6_GUARANTEE_CUSTOMS_TRANSPORT gct inner join accounting_entity ae6 on
+ae6.id = gct.accounting_entity_id) on gct.id = ca.ca6_id
+left join (CA7_GUARANTEE_EXCISE_PRODUCTS gep inner join accounting_entity ae7 on
+ae7.id = gep.accounting_entity_id) on gep.id = ca.ca7_id
+left join (ca8_frct cf inner join ca8_frct_per_discharge cfpd on cfpd.CA8_ID =
+cf.id inner join accounting_entity ae8 on ae8.id = cfpd.accounting_entity_id) on
+cf.id = ca.ca8_id
+group by eo.PARTY_NAME,eo.KBO_NUMBER, ca.IDENTIFICATION_CODE, ca.total_guaranteed
+order by eo.KBO_NUMBER, ca.IDENTIFICATION_CODE
 with ur
     """
     parser = Parser(query)
@@ -423,23 +481,28 @@ with ur
 def test_get_tables_with_leading_digits():
     # see #139
 
-    # Identifiers may begin with a digit but unless quoted may not consist solely of digits.
+    # Identifiers may begin with a digit
+    # but unless quoted may not consist solely of digits.
     assert ["0020"] == Parser("SELECT * FROM `0020`").tables
 
     assert ["0020_big_table"] == Parser(
-        "SELECT t.val as value, count(*) FROM `0020_big_table` as t WHERE id BETWEEN 10 AND 20 GROUP BY val"
+        "SELECT t.val as value, count(*) "
+        "FROM `0020_big_table` as t WHERE id BETWEEN 10 AND 20 GROUP BY val"
     ).tables
     assert ["0020_big_table"] == Parser(
         "SELECT t.val as value, count(*) FROM `0020_big_table`"
     ).tables
     assert ["0020_big_table"] == Parser(
-        'SELECT t.val as value, count(*) FROM "0020_big_table" as t WHERE id BETWEEN 10 AND 20 GROUP BY val'
+        'SELECT t.val as value, count(*) '
+        'FROM "0020_big_table" as t WHERE id BETWEEN 10 AND 20 GROUP BY val'
     ).tables
     assert ["0020_big_table"] == Parser(
-        "SELECT t.val as value, count(*) FROM 0020_big_table as t WHERE id BETWEEN 10 AND 20 GROUP BY val"
+        "SELECT t.val as value, count(*) "
+        "FROM 0020_big_table as t WHERE id BETWEEN 10 AND 20 GROUP BY val"
     ).tables
     assert ["0020_big_table"] == Parser(
-        "SELECT t.val as value, count(*) FROM `0020_big_table` as t WHERE id BETWEEN 10 AND 20 GROUP BY val"
+        "SELECT t.val as value, count(*) "
+        "FROM `0020_big_table` as t WHERE id BETWEEN 10 AND 20 GROUP BY val"
     ).tables
     assert ["0020_big_table"] == Parser(
         "SELECT t.val as value, count(*) FROM 0020_big_table"
@@ -460,7 +523,7 @@ def test_insert_ignore_with_comments():
 
 def test_mutli_from_aliases_without_as():
     query = """
-    select distinct e1.eid as eid from uw_emp "e1", uw_emp "e2", uw_payroll p 
+    select distinct e1.eid as eid from uw_emp "e1", uw_emp "e2", uw_payroll p
     where e1.eid = e2.eid and e1.eid = p.eid
     """
     parser = Parser(query)

--- a/test/test_hive.py
+++ b/test/test_hive.py
@@ -29,11 +29,13 @@ FROM
      (
        year > '{{ beginYear28 }}' OR
        (year = '{{ beginYear28 }}' AND month > '{{ beginMonth28 }}') OR
-       (year = '{{ beginYear28 }}' AND month = '{{ beginMonth28 }}' AND day > '{{ beginDay28 }}')
+       (year = '{{ beginYear28 }}' AND month = '{{ beginMonth28 }}'
+       AND day > '{{ beginDay28 }}')
      ) AND (
        year < '{{ beginYear }}' OR
        (year = '{{ beginYear }}' AND month < '{{ beginMonth }}') OR
-       (year = '{{ beginYear }}' AND month = '{{ beginMonth }}' AND day <= '{{ beginDay }}')
+       (year = '{{ beginYear }}' AND month = '{{ beginMonth }}'
+       AND day <= '{{ beginDay }}')
      )
    GROUP BY wiki_id, beacon) r
 JOIN statsdb.dimension_wikis d ON r.wiki_id = d.wiki_id;

--- a/test/test_limit_and_offset.py
+++ b/test/test_limit_and_offset.py
@@ -39,7 +39,8 @@ def test_comma_separated():
 
     assert Parser(
         "SELECT /* CategoryPaginationViewer::processSection */  "
-        "page_namespace,page_title,page_len,page_is_redirect,cl_sortkey_prefix  FROM `page` "
+        "page_namespace,page_title,page_len,page_is_redirect,cl_sortkey_prefix  "
+        "FROM `page` "
         "INNER JOIN `categorylinks` FORCE INDEX (cl_sortkey) ON ((cl_from = page_id))  "
         "WHERE cl_type = 'page' AND cl_to = 'Spotify/Song'  "
         "ORDER BY cl_sortkey LIMIT 927600,200"

--- a/test/test_mssql_server.py
+++ b/test/test_mssql_server.py
@@ -45,7 +45,7 @@ def test_sql_server_cte():
                 WITH foo AS (
                     SELECT * FROM n
                 )
-                UPDATE z from foo set z.q = foo.y 
+                UPDATE z from foo set z.q = foo.y
                     """
         ).tables
         == ["n", "z"]
@@ -54,10 +54,10 @@ def test_sql_server_cte():
     assert (
         Parser(
             """
-                WITH foo AS ( 
+                WITH foo AS (
                      SELECT * FROM tab
-                ) 
-                DELETE FROM z JOIN foo ON z.a = foo.a  
+                )
+                DELETE FROM z JOIN foo ON z.a = foo.a
                     """.strip()
         ).tables
         == ["tab", "z"]
@@ -67,20 +67,20 @@ def test_sql_server_cte():
 def test_sql_server_cte_sales_by_year():
     sales_query = """
 WITH cte_sales AS (
-    SELECT 
-        staff_id, 
-        COUNT(*) order_count  
+    SELECT
+        staff_id,
+        COUNT(*) order_count
     FROM
         sales.orders
-    WHERE 
+    WHERE
         YEAR(order_date) = 2018
     GROUP BY
         staff_id
 )
 SELECT
     AVG(order_count) average_orders_by_staff
-FROM 
-    cte_sales;  
+FROM
+    cte_sales;
     """.strip()
 
     parser = Parser(sales_query)

--- a/test/test_multiple_subqueries.py
+++ b/test/test_multiple_subqueries.py
@@ -260,7 +260,7 @@ task_type_id = 80
 
     assert parser.subqueries == {
         "a": "SELECT std.task_id as new_task_id "
-             "FROM some_task_detail std WHERE std.STATUS = 1",
+        "FROM some_task_detail std WHERE std.STATUS = 1",
         "b": "SELECT st.task_id FROM some_task st WHERE task_type_id = 80",
     }
 

--- a/test/test_multiple_subqueries.py
+++ b/test/test_multiple_subqueries.py
@@ -8,28 +8,36 @@ SELECT main_qry.*,
        subdays.DAYS_OFFER2,
        subdays.DAYS_OFFER3
 from (
-         SELECT jr.id                                                                                   as PROJECT_ID,
+         SELECT jr.id  as PROJECT_ID,
                 5 * (DATEDIFF(ifnull(lc.creation_date, now()), jr.creation_date) DIV 7)
                     + MID('0123444401233334012222340111123400001234000123440',
-                          7 * WEEKDAY(jr.creation_date) + WEEKDAY(ifnull(lc.creation_date, now())) + 1, 1) as LIFETIME,
+                          7 * WEEKDAY(jr.creation_date)
+                          + WEEKDAY(ifnull(lc.creation_date, now())) + 1, 1)
+                          as LIFETIME,
                 count(distinct
-                      case when jra.application_source = 'VERAMA' then jra.id else null end)                 NUM_APPLICATIONS,
-                count(distinct jra.id)                                                                   NUM_CANDIDATES,
-                sum(case when jro.stage = 'DEAL' then 1 else 0 end)                                 as NUM_CONTRACTED,
-                sum(ifnull(IS_INTERVIEW, 0))                                                            as NUM_INTERVIEWED,
-                sum(ifnull(IS_PRESENTATION, 0))                                                         as NUM_OFFERED
+                      case when jra.application_source = 'VERAMA'
+                        then jra.id else null end)        NUM_APPLICATIONS,
+                count(distinct jra.id) NUM_CANDIDATES,
+                sum(case when jro.stage = 'DEAL' then 1 else 0 end) as NUM_CONTRACTED,
+                sum(ifnull(IS_INTERVIEW, 0)) as NUM_INTERVIEWED,
+                sum(ifnull(IS_PRESENTATION, 0)) as NUM_OFFERED
          from job_request jr
                   left join job_request_application jra on jr.id = jra.job_request_id
-                  left join job_request_offer jro on jro.job_request_application_id = jra.id
-                  left join lifecycle lc on lc.object_id=jr.id and lc.lifecycle_object_type='JOB_REQUEST' 
+                  left join job_request_offer jro
+                  on jro.job_request_application_id = jra.id
+                  left join lifecycle lc on lc.object_id=jr.id
+                  and lc.lifecycle_object_type='JOB_REQUEST'
                   and lc.event = 'JOB_REQUEST_CLOSED'
                   left join (SELECT jro2.job_request_application_id,
                                     max(case
-                                            when jro2.first_interview_scheduled_date is not null then 1
-                                            else 0 end)                                                    as IS_INTERVIEW,
-                                    max(case when jro2.first_presented_date is not null then 1 else 0 end) as IS_PRESENTATION
+                                            when jro2.first_interview_scheduled_date
+                                            is not null then 1
+                                            else 0 end) as IS_INTERVIEW,
+                                    max(case when jro2.first_presented_date is not null
+                                    then 1 else 0 end) as IS_PRESENTATION
                              from job_request_offer jro2
-                             group by 1) jrah2 on jra.id = jrah2.job_request_application_id
+                             group by 1) jrah2
+                             on jra.id = jrah2.job_request_application_id
                   left join client u on jr.client_id = u.id
          where jr.from_point_break = 0
            and u.name not in ('Test', 'Demo Client')
@@ -43,22 +51,27 @@ from (
                  days_to_offer,
                  (SELECT count(distinct jro.job_request_application_id)
                   from job_request_offer jro
-                           left join job_request_application jra2 on jro.job_request_application_id = jra2.id
+                           left join job_request_application jra2
+                           on jro.job_request_application_id = jra2.id
                   where jra2.job_request_id = PROJECT_ID
                     and jro.first_presented_date is not null
                     and jro.first_presented_date <= InitialChangeDate
                  ) as RowNo
           from (
                    SELECT jr.id                    as PROJECT_ID,
-                          5 * (DATEDIFF(jro.first_presented_date, jr.creation_date) DIV 7) +
+                          5 * (
+                          DATEDIFF(jro.first_presented_date, jr.creation_date) DIV 7) +
                           MID('0123444401233334012222340111123400001234000123440',
-                              7 * WEEKDAY(jr.creation_date) + WEEKDAY(jro.first_presented_date) + 1,
+                              7 * WEEKDAY(jr.creation_date)
+                              + WEEKDAY(jro.first_presented_date) + 1,
                               1)                   as days_to_offer,
                           jro.job_request_application_id,
                           jro.first_presented_date as InitialChangeDate
                    from presentation pr
-                            left join presentation_job_request_offer pjro on pr.id = pjro.presentation_id
-                            left join job_request_offer jro on pjro.job_request_offer_id = jro.id
+                            left join presentation_job_request_offer pjro
+                            on pr.id = pjro.presentation_id
+                            left join job_request_offer jro
+                            on pjro.job_request_offer_id = jro.id
                             left join job_request jr on pr.job_request_id = jr.id
                    where jro.first_presented_date is not null) days_sqry) days_final_qry
     group by PROJECT_ID) subdays
@@ -246,7 +259,8 @@ task_type_id = 80
     }
 
     assert parser.subqueries == {
-        "a": "SELECT std.task_id as new_task_id FROM some_task_detail std WHERE std.STATUS = 1",
+        "a": "SELECT std.task_id as new_task_id "
+             "FROM some_task_detail std WHERE std.STATUS = 1",
         "b": "SELECT st.task_id FROM some_task st WHERE task_type_id = 80",
     }
 
@@ -308,10 +322,10 @@ def test_resolving_columns_in_sub_queries_with_join_between_sub_queries():
     Select sq.sub_alias, sq.other_name from (
         select tab1.aa sub_alias, tab2.us as other_name from tab1
         left join tab2 on tab1.id = tab2.other_id
-    ) sq 
+    ) sq
     left join (
         select intern1 as col1, secret col2 from aa
-    ) sq3 on sq.sub_alias = sq3.col1 
+    ) sq3 on sq.sub_alias = sq3.col1
     order by sq.other_name, sq3.col2
     """
 
@@ -343,10 +357,10 @@ def test_resolving_columns_in_sub_queries_union():
     Select sq.sub_alias, sq.other_name from (
         select tab1.aa sub_alias, tab2.us as other_name from tab1
         left join tab2 on tab1.id = tab2.other_id
-    ) sq 
-    union all 
-    select sq3.col1, sq3.col2 from 
-    (select tab12.col1, concat(tab23.ab, ' ', tab23.bc) as col2 
+    ) sq
+    union all
+    select sq3.col1, sq3.col2 from
+    (select tab12.col1, concat(tab23.ab, ' ', tab23.bc) as col2
     from tab12 left join tab23 on tab12.id = tab23.zorro) sq3
     """
 

--- a/test/test_normalization.py
+++ b/test/test_normalization.py
@@ -18,7 +18,7 @@ def test_generalization_of_sql():
             " WHERE cat_title = 'foo'"
         ).generalize
         == "UPDATE `category` SET cat_pages = cat_pages + N,cat_files = cat_files + N"
-           " WHERE cat_title = X"
+        " WHERE cat_title = X"
     )
 
     assert (
@@ -27,7 +27,7 @@ def test_generalization_of_sql():
             "AND (event_date > '20150105141012')"
         ).generalize
         == "SELECT entity_key FROM `wall_notification_queue` WHERE (wiki_id = ) "
-           "AND (event_date > X)"
+        "AND (event_date > X)"
     )
 
     assert (
@@ -47,8 +47,8 @@ def test_generalization_of_sql():
             "AND (page_namespace NOT IN(500,6,14))  ORDER BY page_title"
         ).generalize
         == "SELECT page_id,cl_to FROM `page` "
-           "INNER JOIN `categorylinks` ON ((cl_from = page_id)) "
-           "WHERE cl_to = X AND (page_namespace NOT IN (XYZ)) ORDER BY page_title"
+        "INNER JOIN `categorylinks` ON ((cl_from = page_id)) "
+        "WHERE cl_to = X AND (page_namespace NOT IN (XYZ)) ORDER BY page_title"
     )
 
     assert (
@@ -59,7 +59,7 @@ def test_generalization_of_sql():
             "AND page_namespace = '1'  ORDER BY page_id DESC"
         ).generalize
         == "SELECT page_id,page_title FROM `page` "
-           "WHERE (page_title LIKE X ) AND page_namespace = X ORDER BY page_id DESC"
+        "WHERE (page_title LIKE X ) AND page_namespace = X ORDER BY page_id DESC"
     )
 
     assert (
@@ -83,8 +83,8 @@ def test_generalization_of_sql():
             "AND is_hidden = '0'  ORDER BY id"
         ).generalize
         == "SELECT id,is_read,is_reply,unique_id,entity_key,author_id,notifyeveryone "
-           "FROM `wall_notification` WHERE user_id = X AND wiki_id = X "
-           "AND unique_id IN (XYZ) AND is_hidden = X ORDER BY id"
+        "FROM `wall_notification` WHERE user_id = X AND wiki_id = X "
+        "AND unique_id IN (XYZ) AND is_hidden = X ORDER BY id"
     )
 
     # comments with * inside
@@ -96,8 +96,8 @@ def test_generalization_of_sql():
             "AND page_namespace = '1201'  ORDER BY page_id DESC"
         ).generalize
         == "SELECT page_id,page_title FROM `page` "
-           "WHERE (page_title LIKE X ) "
-           "AND page_namespace = X ORDER BY page_id DESC"
+        "WHERE (page_title LIKE X ) "
+        "AND page_namespace = X ORDER BY page_id DESC"
     )
 
     # comments with * inside
@@ -147,10 +147,10 @@ def test_generalization_of_sql():
             "or  all_groups  LIKE '%vstf;%' ) AND ( edits >= 5)  LIMIT 1  "
         ).generalize
         == "SELECT count(N) as cnt FROM `events_local_users` "
-           "WHERE wiki_id = X AND (user_name != X) "
-           "AND user_is_closed = X "
-           "AND ( single_group = X or all_groups = X or all_groups LIKE X ... ) "
-           "AND ( edits >= N) LIMIT N"
+        "WHERE wiki_id = X AND (user_name != X) "
+        "AND user_is_closed = X "
+        "AND ( single_group = X or all_groups = X or all_groups LIKE X ... ) "
+        "AND ( edits >= N) LIMIT N"
     )
 
     # multiline query
@@ -164,7 +164,7 @@ def test_generalization_of_sql():
     assert (
         Parser(sql).generalize
         == "SELECT page_title FROM page WHERE page_namespace = X "
-           "AND page_title COLLATE LATINN_GENERAL_CI LIKE X"
+        "AND page_title COLLATE LATINN_GENERAL_CI LIKE X"
     )
 
     # queries with IN + brackets (#21)
@@ -197,7 +197,7 @@ def test_generalization_of_sql():
             "in ( 55, 15, 3, 48, 43, 24, 47, 45, 10, 50, 39, 36, 8, 34, 25, 13, 6, 4 )"
         ).generalize
         == "SELECT curation_cms.topics.slug "
-           "from curation_cms.topics where curation_cms.topics.id in (XYZ)"
+        "from curation_cms.topics where curation_cms.topics.id in (XYZ)"
     )
 
 
@@ -229,5 +229,5 @@ def test_generalize_insert():
             "'Cool','null' )"
         ).generalize
         == "INSERT into notification_stats.request_info "
-           "( type, request_id, title, message, details ) values (XYZ)"
+        "( type, request_id, title, message, details ) values (XYZ)"
     )

--- a/test/test_normalization.py
+++ b/test/test_normalization.py
@@ -14,67 +14,143 @@ def test_generalization_of_sql():
 
     assert (
         Parser(
-            "UPDATE  `category` SET cat_pages = cat_pages + 1,cat_files = cat_files + 1 WHERE cat_title = 'foo'"
+            "UPDATE  `category` SET cat_pages = cat_pages + 1,cat_files = cat_files + 1"
+            " WHERE cat_title = 'foo'"
         ).generalize
-        == "UPDATE `category` SET cat_pages = cat_pages + N,cat_files = cat_files + N WHERE cat_title = X"
+        == "UPDATE `category` SET cat_pages = cat_pages + N,cat_files = cat_files + N"
+           " WHERE cat_title = X"
     )
 
     assert (
         Parser(
-            "SELECT  entity_key  FROM `wall_notification_queue`  WHERE (wiki_id = ) AND (event_date > '20150105141012')"
+            "SELECT  entity_key  FROM `wall_notification_queue`  WHERE (wiki_id = ) "
+            "AND (event_date > '20150105141012')"
         ).generalize
-        == "SELECT entity_key FROM `wall_notification_queue` WHERE (wiki_id = ) AND (event_date > X)"
+        == "SELECT entity_key FROM `wall_notification_queue` WHERE (wiki_id = ) "
+           "AND (event_date > X)"
     )
 
     assert (
         Parser(
-            "UPDATE  `user` SET user_touched = '20150112143631' WHERE user_id = '25239755'"
+            "UPDATE  `user` SET user_touched = '20150112143631' "
+            "WHERE user_id = '25239755'"
         ).generalize
         == "UPDATE `user` SET user_touched = X WHERE user_id = X"
     )
 
     assert (
         Parser(
-            "SELECT /* CategoryDataService::getMostVisited 207.46.13.56 */  page_id,cl_to  FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id))  WHERE cl_to = 'Characters' AND (page_namespace NOT IN(500,6,14))  ORDER BY page_title"
+            "SELECT /* CategoryDataService::getMostVisited 207.46.13.56 */  "
+            "page_id,cl_to  FROM `page` "
+            "INNER JOIN `categorylinks` ON ((cl_from = page_id))  "
+            "WHERE cl_to = 'Characters' "
+            "AND (page_namespace NOT IN(500,6,14))  ORDER BY page_title"
         ).generalize
-        == "SELECT page_id,cl_to FROM `page` INNER JOIN `categorylinks` ON ((cl_from = page_id)) WHERE cl_to = X AND (page_namespace NOT IN (XYZ)) ORDER BY page_title"
+        == "SELECT page_id,cl_to FROM `page` "
+           "INNER JOIN `categorylinks` ON ((cl_from = page_id)) "
+           "WHERE cl_to = X AND (page_namespace NOT IN (XYZ)) ORDER BY page_title"
     )
 
     assert (
         Parser(
-            "SELECT /* ArticleCommentList::getCommentList Dancin'NoViolen... */  page_id,page_title  FROM `page`  WHERE (page_title LIKE 'Dreams\\_Come\\_True/@comment-%' ) AND page_namespace = '1'  ORDER BY page_id DESC"
+            "SELECT /* ArticleCommentList::getCommentList Dancin'NoViolen... */  "
+            "page_id,page_title  FROM `page`  "
+            "WHERE (page_title LIKE 'Dreams\\_Come\\_True/@comment-%' ) "
+            "AND page_namespace = '1'  ORDER BY page_id DESC"
         ).generalize
-        == "SELECT page_id,page_title FROM `page` WHERE (page_title LIKE X ) AND page_namespace = X ORDER BY page_id DESC"
+        == "SELECT page_id,page_title FROM `page` "
+           "WHERE (page_title LIKE X ) AND page_namespace = X ORDER BY page_id DESC"
     )
 
     assert (
         Parser(
-            "delete /* DatabaseBase::sourceFile( /usr/wikia/slot1/3690/src/maintenance/cleanupStarter.sql ) CreateWiki scri... */ from text where old_id not in (select rev_text_id from revision)"
+            "delete "
+            "/* "
+            "DatabaseBase::sourceFile(/usr/wikia/src/maintenance/cleanupStarter.sql ) "
+            "CreateWiki scri... */ "
+            "from text where old_id not in (select rev_text_id from revision)"
         ).generalize
         == "delete from text where old_id not in (select rev_text_id from revision)"
     )
 
     assert (
         Parser(
-            "SELECT /* WallNotifications::getBackupData Craftindiedo */  id,is_read,is_reply,unique_id,entity_key,author_id,notifyeveryone  FROM `wall_notification`  WHERE user_id = '24944488' AND wiki_id = '1030786' AND unique_id IN ('880987','882618','708228','522330','662055','837815','792393','341504','600103','612640','667267','482428','600389','213400','620177','164442','659210','621286','609757','575865','567668','398132','549770','495396','344814','421448','400650','411028','341771','379461','332587','314176','284499','250207','231714')  AND is_hidden = '0'  ORDER BY id"
+            "SELECT /* WallNotifications::getBackupData Craftindiedo */  "
+            "id,is_read,is_reply,unique_id,entity_key,author_id,notifyeveryone  "
+            "FROM `wall_notification`  WHERE user_id = '24944488' "
+            "AND wiki_id = '1030786' AND unique_id "
+            "IN ('880987','882618','708228','522330','662055','837815','792393')  "
+            "AND is_hidden = '0'  ORDER BY id"
         ).generalize
-        == "SELECT id,is_read,is_reply,unique_id,entity_key,author_id,notifyeveryone FROM `wall_notification` WHERE user_id = X AND wiki_id = X AND unique_id IN (XYZ) AND is_hidden = X ORDER BY id"
+        == "SELECT id,is_read,is_reply,unique_id,entity_key,author_id,notifyeveryone "
+           "FROM `wall_notification` WHERE user_id = X AND wiki_id = X "
+           "AND unique_id IN (XYZ) AND is_hidden = X ORDER BY id"
     )
 
     # comments with * inside
     assert (
         Parser(
-            "SELECT /* ArticleCommentList::getCommentList *Crashie* */  page_id,page_title  FROM `page`  WHERE (page_title LIKE 'Dainava/@comment-%' ) AND page_namespace = '1201'  ORDER BY page_id DESC"
+            "SELECT /* ArticleCommentList::getCommentList *Crashie* */  "
+            "page_id,page_title  FROM `page`  "
+            "WHERE (page_title LIKE 'Dainava/@comment-%' ) "
+            "AND page_namespace = '1201'  ORDER BY page_id DESC"
         ).generalize
-        == "SELECT page_id,page_title FROM `page` WHERE (page_title LIKE X ) AND page_namespace = X ORDER BY page_id DESC"
+        == "SELECT page_id,page_title FROM `page` "
+           "WHERE (page_title LIKE X ) "
+           "AND page_namespace = X ORDER BY page_id DESC"
     )
 
     # comments with * inside
     assert (
         Parser(
-            "SELECT /* ListusersData::loadData Lart96 - 413bc6e5-b151-44fd-80bd-3baff733fb91 */  count(0) as cnt  FROM `events_local_users`  WHERE wiki_id = '7467' AND (user_name != '') AND user_is_closed = '0' AND ( single_group = 'poweruser' or  all_groups = ''  or  all_groups  LIKE '%bot'  or  all_groups  LIKE '%bot;%'  or  all_groups  LIKE '%bureaucrat'  or  all_groups  LIKE '%bureaucrat;%'  or  all_groups  LIKE '%sysop'  or  all_groups  LIKE '%sysop;%'  or  all_groups  LIKE '%authenticated'  or  all_groups  LIKE '%authenticated;%'  or  all_groups  LIKE '%bot-global'  or  all_groups  LIKE '%bot-global;%'  or  all_groups  LIKE '%content-reviewer'  or  all_groups  LIKE '%content-reviewer;%'  or  all_groups  LIKE '%council'  or  all_groups  LIKE '%council;%'  or  all_groups  LIKE '%fandom-editor'  or  all_groups  LIKE '%fandom-editor;%'  or  all_groups  LIKE '%helper'  or  all_groups  LIKE '%helper;%'  or  all_groups  LIKE '%restricted-login'  or  all_groups  LIKE '%restricted-login;%'  or  all_groups  LIKE '%restricted-login-exempt'  or  all_groups  LIKE '%restricted-login-exempt;%'  or  all_groups  LIKE '%reviewer'  or  all_groups  LIKE '%reviewer;%'  or  all_groups  LIKE '%staff'  or  all_groups  LIKE '%staff;%'  or  all_groups  LIKE '%translator'  or  all_groups  LIKE '%translator;%'  or  all_groups  LIKE '%util'  or  all_groups  LIKE '%util;%'  or  all_groups  LIKE '%vanguard'  or  all_groups  LIKE '%vanguard;%'  or  all_groups  LIKE '%voldev'  or  all_groups  LIKE '%voldev;%'  or  all_groups  LIKE '%vstf'  or  all_groups  LIKE '%vstf;%' ) AND ( edits >= 5)  LIMIT 1  "
+            "SELECT "
+            "/* "
+            "ListusersData::loadData Lart96 - 413bc6e5-b151-44fd-80bd-3baff733fb91 "
+            "*/"
+            " count(0) as cnt  "
+            "FROM `events_local_users`  "
+            "WHERE wiki_id = '7467' "
+            "AND (user_name != '') AND user_is_closed = '0' "
+            "AND ( single_group = 'poweruser' or  all_groups = ''  "
+            "or  all_groups  LIKE '%bot'  or  all_groups  LIKE '%bot;%'  "
+            "or  all_groups  LIKE '%bureaucrat'  or  all_groups  LIKE '%bureaucrat;%'  "
+            "or  all_groups  LIKE '%sysop'  or  all_groups  LIKE '%sysop;%'  "
+            "or  all_groups  LIKE '%authenticated'  "
+            "or  all_groups  LIKE '%authenticated;%'  "
+            "or  all_groups  LIKE '%bot-global'  "
+            "or  all_groups  LIKE '%bot-global;%'  "
+            "or  all_groups  LIKE '%content-reviewer'  "
+            "or  all_groups  LIKE '%content-reviewer;%'  "
+            "or  all_groups  LIKE '%council'  "
+            "or  all_groups  LIKE '%council;%'  "
+            "or  all_groups  LIKE '%fandom-editor'  "
+            "or  all_groups  LIKE '%fandom-editor;%'  "
+            "or  all_groups  LIKE '%helper'  "
+            "or  all_groups  LIKE '%helper;%'  "
+            "or  all_groups  LIKE '%restricted-login'  "
+            "or  all_groups  LIKE '%restricted-login;%'  "
+            "or  all_groups  LIKE '%restricted-login-exempt'  "
+            "or  all_groups  LIKE '%restricted-login-exempt;%'  "
+            "or  all_groups  LIKE '%reviewer'  "
+            "or  all_groups  LIKE '%reviewer;%'  "
+            "or  all_groups  LIKE '%staff'  "
+            "or  all_groups  LIKE '%staff;%'  "
+            "or  all_groups  LIKE '%translator'  "
+            "or  all_groups  LIKE '%translator;%'  "
+            "or  all_groups  LIKE '%util'  "
+            "or  all_groups  LIKE '%util;%'  "
+            "or  all_groups  LIKE '%vanguard'  "
+            "or  all_groups  LIKE '%vanguard;%'  "
+            "or  all_groups  LIKE '%voldev'  "
+            "or  all_groups  LIKE '%voldev;%'  "
+            "or  all_groups  LIKE '%vstf'  "
+            "or  all_groups  LIKE '%vstf;%' ) AND ( edits >= 5)  LIMIT 1  "
         ).generalize
-        == "SELECT count(N) as cnt FROM `events_local_users` WHERE wiki_id = X AND (user_name != X) AND user_is_closed = X AND ( single_group = X or all_groups = X or all_groups LIKE X ... ) AND ( edits >= N) LIMIT N"
+        == "SELECT count(N) as cnt FROM `events_local_users` "
+           "WHERE wiki_id = X AND (user_name != X) "
+           "AND user_is_closed = X "
+           "AND ( single_group = X or all_groups = X or all_groups LIKE X ... ) "
+           "AND ( edits >= N) LIMIT N"
     )
 
     # multiline query
@@ -87,7 +163,8 @@ def test_generalization_of_sql():
 
     assert (
         Parser(sql).generalize
-        == "SELECT page_title FROM page WHERE page_namespace = X AND page_title COLLATE LATINN_GENERAL_CI LIKE X"
+        == "SELECT page_title FROM page WHERE page_namespace = X "
+           "AND page_title COLLATE LATINN_GENERAL_CI LIKE X"
     )
 
     # queries with IN + brackets (#21)
@@ -103,23 +180,32 @@ def test_generalization_of_sql():
 
     assert (
         Parser(
-            "SELECT foo FROM bar WHERE slug in (         'american-horror-story', 'animated-series', 'batman', 'comics', 'dc', 'fallout',          'game-of-thrones', 'hbo', 'horror', 'marvel', 'mcu', 'movie-reviews', 'movie-trailers',          'movies', 'netflix', 'playstation', 'star-wars', 'stranger-things', 'streaming',          'the-simpsons', 'zelda'       )"
+            "SELECT foo FROM bar WHERE slug in ('american-horror-story', "
+            "'animated-series', 'batman', 'comics', 'dc', 'fallout',"
+            "'game-of-thrones', 'hbo', 'horror', 'marvel', 'mcu', "
+            "'movie-reviews', 'movie-trailers', 'movies', 'netflix', "
+            "'playstation', 'star-wars', 'stranger-things', 'streaming',"
+            "'the-simpsons', 'zelda')"
         ).generalize
         == "SELECT foo FROM bar WHERE slug in (XYZ)"
     )
 
     assert (
         Parser(
-            "SELECT curation_cms.topics.slug from curation_cms.topics where curation_cms.topics.id in (   87, 86, 79, 77, 76, 73, 72, 70, 71, 69, 68, 66, 65, 64, 62, 63, 2, 57, 17, 1,    22, 49, 30, 55, 15, 3, 48, 43, 24, 47, 45, 10, 50, 39, 36, 8, 34, 25, 13, 6, 4 )"
+            "SELECT curation_cms.topics.slug "
+            "from curation_cms.topics where curation_cms.topics.id "
+            "in ( 55, 15, 3, 48, 43, 24, 47, 45, 10, 50, 39, 36, 8, 34, 25, 13, 6, 4 )"
         ).generalize
-        == "SELECT curation_cms.topics.slug from curation_cms.topics where curation_cms.topics.id in (XYZ)"
+        == "SELECT curation_cms.topics.slug "
+           "from curation_cms.topics where curation_cms.topics.id in (XYZ)"
     )
 
 
 def test_generalize_timestamp():
     assert (
         Parser(
-            # ODBC syntax - https://dev.mysql.com/doc/refman/5.7/en/date-and-time-literals.html
+            # ODBC syntax
+            # https://dev.mysql.com/doc/refman/5.7/en/date-and-time-literals.html
             "SELECT foo FROM bar WHERE publish_date < {ts '2018-04-05 10:14:33.824'}"
         ).generalize
         == "SELECT foo FROM bar WHERE publish_date < {ts X}"
@@ -134,7 +220,14 @@ def test_generalize_insert():
 
     assert (
         Parser(
-            "/* 7e6384e5 */ INSERT into notification_stats.request_info (   type,    request_id,    title,    message,    details ) values (   'action-notification',    '51f8a962-bae0-4d25-9341-130658161541',    'RickSanchez15 replied to What''s your overall favourite Season of South Park?.',    'Cool',    'null' )"
+            "/* 7e6384e5 */ INSERT into notification_stats.request_info "
+            "(   type,    request_id,    title,    message,    details ) "
+            "values ('action-notification', "
+            "'51f8a962-bae0-4d25-9341-130658161541',"
+            "'RickSanchez15 replied to What''s your overall "
+            "favourite Season of South Park?.', "
+            "'Cool','null' )"
         ).generalize
-        == "INSERT into notification_stats.request_info ( type, request_id, title, message, details ) values (XYZ)"
+        == "INSERT into notification_stats.request_info "
+           "( type, request_id, title, message, details ) values (XYZ)"
     )

--- a/test/test_postgress.py
+++ b/test/test_postgress.py
@@ -13,7 +13,8 @@ def test_postgress_quoted_names():
     assert parser.values == ["foo"]
 
     parser = Parser(
-        'SELECT "test"."id", "test"."name" FROM "test" WHERE "test"."name" = \'foo\' LIMIT 21 FOR UPDATE'
+        'SELECT "test"."id", "test"."name" FROM "test" '
+        'WHERE "test"."name" = \'foo\' LIMIT 21 FOR UPDATE'
     )
     assert ["test"] == parser.tables
     assert ["test.id", "test.name"] == parser.columns

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -24,7 +24,7 @@ def test_preprocessing():
             "INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id"
         ).query
         == "SELECT r1.wiki_id AS id FROM report_wiki_recent_pageviews AS r1 "
-           "INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id"
+        "INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id"
     )
 
     # comments are kept
@@ -52,7 +52,7 @@ def test_preprocessing():
             "and aa =' as \"aa.oo\" '"
         ).query
         == "SELECT * from aa where name = 'test name with \"aa\" in string' "
-           "and aa =' as \"aa.oo\" '"
+        "and aa =' as \"aa.oo\" '"
     )
 
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -20,9 +20,11 @@ def test_preprocessing():
 
     assert (
         Parser(
-            "SELECT r1.wiki_id AS id FROM report_wiki_recent_pageviews AS r1 INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id"
+            "SELECT r1.wiki_id AS id FROM report_wiki_recent_pageviews AS r1 "
+            "INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id"
         ).query
-        == "SELECT r1.wiki_id AS id FROM report_wiki_recent_pageviews AS r1 INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id"
+        == "SELECT r1.wiki_id AS id FROM report_wiki_recent_pageviews AS r1 "
+           "INNER JOIN dimension_wikis AS d ON r.wiki_id = d.wiki_id"
     )
 
     # comments are kept
@@ -46,9 +48,11 @@ def test_preprocessing():
     )
     assert (
         Parser(
-            "SELECT * from aa where name = 'test name with \"aa\" in string' and aa =' as \"aa.oo\" '"
+            "SELECT * from aa where name = 'test name with \"aa\" in string' "
+            "and aa =' as \"aa.oo\" '"
         ).query
-        == "SELECT * from aa where name = 'test name with \"aa\" in string' and aa =' as \"aa.oo\" '"
+        == "SELECT * from aa where name = 'test name with \"aa\" in string' "
+           "and aa =' as \"aa.oo\" '"
     )
 
 

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -65,8 +65,10 @@ def test_getting_values():
         "test comment",
         0,
         "0",
-        ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv: 78.0) "
-         "Gecko/20100101 Firefox/78.0"),
+        (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv: 78.0) "
+            "Gecko/20100101 Firefox/78.0"
+        ),
         "comment",
         0,
         0,
@@ -83,8 +85,10 @@ def test_getting_values():
         "comment_content": "test comment",
         "comment_karma": 0,
         "comment_approved": "0",
-        "comment_agent": ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv: 78.0) "
-                          "Gecko/20100101 Firefox/78.0"),
+        "comment_agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv: 78.0) "
+            "Gecko/20100101 Firefox/78.0"
+        ),
         "comment_type": "comment",
         "comment_parent": 0,
         "user_id": 0,

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -3,7 +3,9 @@ from sql_metadata import Parser
 
 def test_getting_values():
     parser = Parser(
-        "INSERT /* VoteHelper::addVote xxx */  INTO `page_vote` (article_id,user_id,`time`) VALUES ('442001','27574631','20180228130846')"
+        "INSERT /* VoteHelper::addVote xxx */  "
+        "INTO `page_vote` (article_id,user_id,`time`) "
+        "VALUES ('442001','27574631','20180228130846')"
     )
     assert parser.values == ["442001", "27574631", "20180228130846"]
     assert parser.values_dict == {
@@ -14,7 +16,8 @@ def test_getting_values():
 
     # REPLACE queries
     parser = Parser(
-        "REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) VALUES ('47','infoboxes','')"
+        "REPLACE INTO `page_props` (pp_page,pp_propname,pp_value) "
+        "VALUES ('47','infoboxes','')"
     )
     assert parser.values == ["47", "infoboxes", ""]
     assert parser.values_dict == {
@@ -24,7 +27,8 @@ def test_getting_values():
     }
 
     parser = Parser(
-        "/* method */ INSERT IGNORE INTO `0070_insert_ignore_table` VALUES (9, 2.15, '123', '2017-01-01');"
+        "/* method */ INSERT IGNORE INTO `0070_insert_ignore_table` "
+        "VALUES (9, 2.15, '123', '2017-01-01');"
     )
     assert parser.query_type == "INSERT"
     assert parser.values == [9, 2.15, "123", "2017-01-01"]
@@ -40,7 +44,15 @@ def test_getting_values():
     assert Parser("SELECT * from foo;").values_dict is None
 
     parser = Parser(
-        "INSERT INTO `wp_comments` (`comment_post_ID`, `comment_author`, `comment_author_email`, `comment_author_url`, `comment_author_IP`, `comment_date`, `comment_date_gmt`, `comment_content`, `comment_karma`, `comment_approved`, `comment_agent`, `comment_type`, `comment_parent`, `user_id`) VALUES (1, 'test user', '', '', '127.0.0.1', '2021-02-27 03:21:52', '2021-02-27 03:21:52', 'test comment', 0, '0', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv: 78.0) Gecko/20100101 Firefox/78.0', 'comment', 0, 0)',"
+        "INSERT INTO `wp_comments` (`comment_post_ID`, `comment_author`, "
+        "`comment_author_email`, `comment_author_url`, `comment_author_IP`, "
+        "`comment_date`, `comment_date_gmt`, `comment_content`, `comment_karma`, "
+        "`comment_approved`, `comment_agent`, `comment_type`, `comment_parent`, "
+        "`user_id`) VALUES (1, 'test user', '', '', '127.0.0.1', '2021-02-27 03:21:52',"
+        " '2021-02-27 03:21:52', 'test comment', 0, '0', "
+        "'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv: 78.0) "
+        "Gecko/20100101 Firefox/78.0', "
+        "'comment', 0, 0)',"
     )
     assert parser.values == [
         1,
@@ -53,7 +65,8 @@ def test_getting_values():
         "test comment",
         0,
         "0",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv: 78.0) Gecko/20100101 Firefox/78.0",
+        ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv: 78.0) "
+         "Gecko/20100101 Firefox/78.0"),
         "comment",
         0,
         0,
@@ -70,7 +83,8 @@ def test_getting_values():
         "comment_content": "test comment",
         "comment_karma": 0,
         "comment_approved": "0",
-        "comment_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv: 78.0) Gecko/20100101 Firefox/78.0",
+        "comment_agent": ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv: 78.0) "
+                          "Gecko/20100101 Firefox/78.0"),
         "comment_type": "comment",
         "comment_parent": 0,
         "user_id": 0,

--- a/test/test_with_statements.py
+++ b/test/test_with_statements.py
@@ -6,7 +6,7 @@ def test_with_statements():
     parser = Parser(
         """
 WITH
-database1.tableFromWith AS (SELECT aa.* FROM table3 as aa 
+database1.tableFromWith AS (SELECT aa.* FROM table3 as aa
                             left join table4 on aa.col1=table4.col2),
 test as (SELECT * from table3)
 SELECT
@@ -94,9 +94,9 @@ def test_multiple_with_statements_with_with_columns():
     # fix for setting columns in with
     # https://github.com/macbre/sql-metadata/issues/128
     query = """
-    WITH 
+    WITH
     t1 (c1, c2) AS (SELECT * FROM t2),
-    t3 (c3, c4) AS (SELECT c5, c6 FROM t4) 
+    t3 (c3, c4) AS (SELECT c5, c6 FROM t4)
     SELECT * FROM t1, t3;
     """
     parser = Parser(query)
@@ -175,10 +175,10 @@ def test_complicated_with():
 
 def test_resolving_with_clauses_with_columns():
     query = """
-    WITH 
+    WITH
     query1 (c1, c2) AS (SELECT * FROM t2),
-    query2 (c3, c4) AS (SELECT c5, c6 FROM t4) 
-    SELECT query1.c2, query2.c4 
+    query2 (c3, c4) AS (SELECT c5, c6 FROM t4)
+    SELECT query1.c2, query2.c4
     FROM query1 left join query2 on query1.c1 = query2.c3
     order by query1.c2;
     """
@@ -207,10 +207,10 @@ def test_resolving_with_clauses_with_columns():
 
 def test_resolving_with_columns():
     query = """
-    WITH 
+    WITH
     query1 AS (SELECT c1, c2 FROM t5),
-    query2 AS (SELECT c3, c4 FROM t6) 
-    SELECT query1.c2, query2.c4 
+    query2 AS (SELECT c3, c4 FROM t6)
+    SELECT query1.c2, query2.c4
     FROM query1 left join query2 on query1.c1 = query2.c3
     order by query1.c2;
     """
@@ -223,7 +223,7 @@ def test_resolving_with_columns():
     assert parser.tables == ["t5", "t6"]
     assert parser.columns_aliases == {}
     assert parser.columns_aliases_names == []
-    assert parser.columns_aliases_dict == None
+    assert parser.columns_aliases_dict is None
     assert parser.columns == ["c1", "c2", "c3", "c4"]
     assert parser.columns_dict == {
         "join": ["c1", "c3"],
@@ -235,10 +235,10 @@ def test_resolving_with_columns():
 
 def test_resolving_with_columns_with_wildcard():
     query = """
-    WITH 
+    WITH
     query1 AS (SELECT c1, c2, c4 FROM t5),
-    query2 AS (SELECT c3, c7 FROM t6) 
-    SELECT query1.*, query2.c7 
+    query2 AS (SELECT c3, c7 FROM t6)
+    SELECT query1.*, query2.c7
     FROM query1 left join query2 on query1.c4 = query2.c3
     order by query2.c7;
     """
@@ -262,10 +262,10 @@ def test_resolving_with_columns_with_wildcard():
 
 def test_resolving_with_columns_with_nested_tables_prefixes():
     query = """
-    WITH 
+    WITH
     query1 AS (SELECT t5.c1, t5.c2, t6.c4 FROM t5 left join t6 on t5.link1=t6.link2),
-    query2 AS (SELECT c3, c7 FROM t7 union all select c4, c12 from t8) 
-    SELECT query1.*, query2.c7, query2.c3 
+    query2 AS (SELECT c3, c7 FROM t7 union all select c4, c12 from t8)
+    SELECT query1.*, query2.c7, query2.c3
     FROM query1 left join query2 on query1.c4 = query2.c3
     order by query2.c7;
     """
@@ -310,7 +310,7 @@ def test_resolving_with_columns_with_nested_tables_prefixes():
 
 def test_nested_with_statement_in_create_table():
     qry = """
-            CREATE table xyz as 
+            CREATE table xyz as
             with sub as (select it_id from internal_table)
             SELECT *
             from (


### PR DESCRIPTION
Fix for from clause in extract function close: #186
Fix for wrong alias check, close #188

Some simplifications:
- Added `TokenType` enum and `token_type` to token and populate it with enum value
- Merged token values with tables and database delimiter into one token and removed left_expand token property
- Cleaned no longer required checks for `is_dot` property as there are no dot tokens anymore
- Moved populating `column_aliases_dict` dictionary to `column_aliases_names`
- Added flake8 to warn about complexity before CodeFactor - also split long string lines and remove trailing whitespace