### PR TITLE
Ignore failed coverage uploads to Coveralls

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -69,7 +69,7 @@ jobs:
       if: matrix.python-version == '3.9'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: poetry run coveralls --service=github
+      run: poetry run coveralls --service=github || true
 
     - name: Lint with pylint
       run: make lint


### PR DESCRIPTION
```
coveralls.exception.CoverallsException: Could not submit coverage: 405 Client Error: Not Allowed for url: https://coveralls.io/api/v1/jobs
```