### PR TITLE
Add interactive demo link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Supported queries syntax:
 
 (note that listed backends can differ quite substantially but should work in regard of query types supported by `sql-metadata`)
 
+You can test the capabilities of `sql-metadata` with an interactive demo: [https://sql-app.infocruncher.com/](https://sql-app.infocruncher.com/)
+
 ## Usage
 
 ```


### PR DESCRIPTION
I've created a small demo site showcasing sql-metadata that you can checkout here: https://sql-app.infocruncher.com/

It's served by API Gateway and Lambda, code for it is available also: https://github.com/dylanhogg/sql-app

I thought it may be useful to include a reference to the demo from the README.