### PR TITLE
Allow using keyword as table alias

### DIFF
--- a/sql_metadata/token.py
+++ b/sql_metadata/token.py
@@ -4,7 +4,7 @@ Module contains internal SQLToken that creates linked list
 from typing import Dict, List, Union
 
 import sqlparse.sql
-from sqlparse.tokens import Comment, Name, Number, Punctuation, Wildcard
+from sqlparse.tokens import Comment, Name, Number, Punctuation, Wildcard, Keyword
 
 from sql_metadata.keywords_lists import (
     KEYWORDS_BEFORE_COLUMNS,
@@ -41,6 +41,7 @@ class SQLToken:  # pylint: disable=R0902, R0904
             self.is_integer = tok.ttype is Number.Integer
             self.is_float = tok.ttype is Number.Float
             self.is_comment = tok.ttype is Comment or tok.ttype.parent == Comment
+            self.is_as_keyword = tok.ttype is Keyword and tok.normalized == "AS"
 
             self.is_left_parenthesis = str(tok) == "("
             self.is_right_parenthesis = str(tok) == ")"
@@ -62,6 +63,7 @@ class SQLToken:  # pylint: disable=R0902, R0904
         self.is_integer = False
         self.is_float = False
         self.is_comment = False
+        self.is_as_keyword = False
 
         self.is_left_parenthesis = False
         self.is_right_parenthesis = False

--- a/test/test_aliases.py
+++ b/test/test_aliases.py
@@ -6,6 +6,13 @@ def test_get_query_table_aliases():
     assert Parser("SELECT bar FROM foo AS f").tables_aliases == {"f": "foo"}
     assert Parser("SELECT bar FROM foo f").tables_aliases == {"f": "foo"}
     assert Parser("SELECT bar AS value FROM foo AS f").tables_aliases == {"f": "foo"}
+    # use SQL keywords as table aliases
+    assert Parser("SELECT system.bar FROM foo AS system").tables_aliases == {
+        "system": "foo"
+    }
+    assert Parser("SELECT system.bar FROM foo system").tables_aliases == {
+        "system": "foo"
+    }
     assert Parser(
         "SELECT bar AS value FROM foo AS f INNER JOIN dimensions AS d ON f.id = d.id"
     ).tables_aliases == {"f": "foo", "d": "dimensions"}

--- a/test/test_getting_tables.py
+++ b/test/test_getting_tables.py
@@ -622,3 +622,23 @@ def test_with_keyword_in_joins():
     ]
 
     assert parser.with_names == ["CTE_RANGE"]
+
+
+def test_getting_proper_tables_with_keyword_aliases():
+    # use SQL keywords as table aliases
+    assert Parser("SELECT system.bar FROM foo AS system").tables == ["foo"]
+    assert Parser("SELECT system.bar FROM foo system").tables == ["foo"]
+
+    assert Parser(
+        "SELECT system.bar FROM foo system union all select * from b user"
+    ).tables == ["foo", "b"]
+
+    query = """
+    SELECT system.bar FROM foo system 
+    join select user.asd as val from b user on user.gfd=system.bar
+    """
+
+    assert Parser(query).tables == ["foo", "b"]
+    assert Parser(query).columns == ["foo.bar", "b.asd", "b.gfd"]
+    assert Parser(query).columns_aliases == {"val": "b.asd"}
+    assert Parser(query).tables_aliases == {"system": "foo", "user": "b"}


### PR DESCRIPTION
This PR tries to solve issue #277 

When checking if a token can be a potential table alias, I add non `AS` keyword as a valid table alias.

For a valid query like below (only Oracle consider `SYSTEM` as keyword according to this list, https://github.com/andialbrecht/sqlparse/blob/e66046785b816e5c2d22f101f36faefd19c4a771/sqlparse/keywords.py):
```SQL
SELECT system.id
FROM foo system
```

`parser.tables_aliases` will correctly return `{"system": "foo"}`

For Oracle, this query is probably invalid, this approach will still return the same table aliases, but I don't think this probably matters less comparing to not returning correct table aliases for even valid queries.

In the PR, I added a new member variable `is_as_keyword` to `Token`, and I found several places of code uses `token.normalized == "AS"` so I refactored the code a little bit to take advantage of the new variable.
