### PR TITLE
Do not consider `AS (` from window clause as query start

### DIFF
--- a/sql_metadata/keywords_lists.py
+++ b/sql_metadata/keywords_lists.py
@@ -117,4 +117,5 @@ RELEVANT_KEYWORDS = {
     "VALUES",
     "INDEX",
     "WITH",
+    "WINDOW",
 }

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -844,7 +844,11 @@ class Parser:  # pylint: disable=R0902
         elif token.previous_token.normalized in KEYWORDS_BEFORE_COLUMNS.union({","}):
             # we are in columns and in a column subquery definition
             token.is_column_definition_start = True
-        elif token.previous_token.is_as_keyword:
+        elif (
+            token.previous_token.is_as_keyword
+            and token.last_keyword_normalized != "WINDOW"
+        ):
+            # window clause also contains AS keyword, but it is not a query
             token.is_with_query_start = True
         elif (
             token.last_keyword_normalized == "TABLE"

--- a/test/test_with_statements.py
+++ b/test/test_with_statements.py
@@ -425,3 +425,29 @@ def test_insert_overwrite():
         "db1.tb1.col3",
     ]
     assert parser.tables == ["db1.tb1", "db4.tb25"]
+
+
+def test_window_in_with():
+    query = """
+        WITH cte_1 AS (
+            SELECT
+                column_1, column_2
+            FROM
+                table_1
+            WINDOW window_1 AS (
+                PARTITION BY column_2
+            )
+        )
+        SELECT
+            column_1, column_2
+        FROM
+            cte_1 AS alias_1
+    """
+
+    parser = Parser(query)
+    assert parser.with_names == ["cte_1"]
+    assert parser.columns == ["column_1", "column_2"]
+    assert parser.with_queries == {
+        "cte_1": "SELECT column_1, column_2 FROM table_1 WINDOW window_1 AS(PARTITION BY column_2)"
+    }
+    assert parser.tables == ["table_1"]


### PR DESCRIPTION
Fix for https://github.com/macbre/sql-metadata/issues/309