### PR TITLE
Handle when column name wildcard is prefixed by table name #296

### DIFF
--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -815,6 +815,9 @@ class Parser:  # pylint: disable=R0902
             # handle case when column name is used but subquery select all by wildcard
             if "*" in subparser.columns:
                 return column_name
+            for table in subparser.tables:
+                if f"{table}.*" in subparser.columns:
+                    return column_name
             raise exc  # pragma: no cover
         resolved_column = subparser.columns[column_index]
         return [resolved_column]

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -782,7 +782,8 @@ class Parser:  # pylint: disable=R0902
         return column if isinstance(column, list) else [column]
 
     @staticmethod
-    def _resolve_nested_query(
+    # pylint:disable=too-many-return-statements
+    def _resolve_nested_query(  # noqa: C901
         subquery_alias: str,
         nested_queries_names: List[str],
         nested_queries: Dict,

--- a/test/test_getting_columns.py
+++ b/test/test_getting_columns.py
@@ -92,10 +92,15 @@ def test_getting_columns():
         "test",
     ]
     assert Parser("SELECT /* a comment */ bar FROM test_table").columns == ["bar"]
-    assert Parser(
-        "WITH foo AS (SELECT test_table.* FROM test_table)"
-        "SELECT foo.bar FROM foo"
-    ).columns == ["test_table.*", "bar"]
+    assert (
+        Parser(
+            """
+                WITH foo AS (SELECT test_table.* FROM test_table)
+                SELECT foo.bar FROM foo
+            """
+        ).columns
+        == ["test_table.*", "bar"]
+    )
 
 
 def test_columns_with_order_by():

--- a/test/test_getting_columns.py
+++ b/test/test_getting_columns.py
@@ -92,6 +92,10 @@ def test_getting_columns():
         "test",
     ]
     assert Parser("SELECT /* a comment */ bar FROM test_table").columns == ["bar"]
+    assert Parser(
+        "WITH foo AS (SELECT test_table.* FROM test_table)"
+        "SELECT foo.bar FROM foo"
+    ).columns == ["test_table.*", "bar"]
 
 
 def test_columns_with_order_by():


### PR DESCRIPTION
Query to reproduce:

```python
parsed = Parser("""
with cte_one as (
    select table_one.*
    from table_one
)

select cte_one.column_one
from cte_one
""")
```

Above code will fail when getting `parsed.columns`. But if the query of cte_one is `select * from table_one` it is succeeded.

This PR add handler for `if f"{table}.*" in subparser.columns` to make above query success to parse.

---

See #296 for a original PR from @sumartoyo.