### PR TITLE
Force the Poetry version to 1.1.14

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -45,8 +45,9 @@ jobs:
 
     # https://github.com/marketplace/actions/install-poetry-action
     - name: Install Poetry
-      uses: snok/install-poetry@v1.3
+      uses: snok/install-poetry@v1.3.1
       with:
+        version: 1.1.14
         virtualenvs-create: true
         virtualenvs-in-project: true
 


### PR DESCRIPTION
Otherwise we get:

```
Installing Poetry 👷

Retrieving Poetry metadata

# Welcome to Poetry!

This will download and install the latest version of Poetry,
a dependency and package manager for Python.

It will add the `poetry` command to Poetry's bin directory, located at:

/home/runner/.local/bin

You can uninstall at any time by executing this script with the --uninstall option,
and these changes will be reverted.

Installing Poetry (1.2.0)
Installing Poetry (1.2.0): Creating environment
Installing Poetry (1.2.0): Installing Poetry
Installing Poetry (1.2.0): Creating script
Installing Poetry (1.2.0): Done

Poetry (1.2.0) is installed now. Great!

You can test that everything is set up by executing:

`poetry --version`

/home/runner/work/_actions/snok/install-poetry/v1.3/main.sh: line 33: poetry: command not found
/home/runner/work/_actions/snok/install-poetry/v1.3/main.sh: line 34: poetry: command not found
/home/runner/work/_actions/snok/install-poetry/v1.3/main.sh: line [35](https://github.com/macbre/sql-metadata/runs/8131847810?check_suite_focus=true#step:7:37): poetry: command not found
/home/runner/work/_actions/snok/install-poetry/v1.3/main.sh: line [37](https://github.com/macbre/sql-metadata/runs/8131847810?check_suite_focus=true#step:7:39): poetry: command not found
```