### PR TITLE
feature/Let the user disable the Logger

### DIFF
--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -30,8 +30,10 @@ class Parser:  # pylint: disable=R0902
     Main class to parse sql query
     """
 
-    def __init__(self, sql: str = "") -> None:
+    def __init__(self, sql: str = "", logging: bool = True) -> None:
         self._logger = logging.getLogger(self.__class__.__name__)
+        if not logging:
+            self._logger.disabled = True
 
         self._raw_query = sql
         self._query = self._preprocess_query()


### PR DESCRIPTION
When using the Parser as part of a library, there are cases where I know that some of my queries aren't going to be supported. I don't need the logger to be constantly printing "Not supported query type:" as well as raising an exception that I handle...

Either remove the (in my opinion) useless logger, or simplify disabling it so a weird work around like this isn't necessary:
```
parser = sql_metadata.Parser()
parser._logger.disabled = True
parser.__init__(query)
```
And instead this could be used:
```
parsed = sql_medatadata.Parser(query, False)
```