### PR TITLE
Parser.tokens: ignore flake8 error

### DIFF
--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -124,7 +124,7 @@ class Parser:  # pylint: disable=R0902
         return self._query_type
 
     @property
-    def tokens(self) -> List[SQLToken]:
+    def tokens(self) -> List[SQLToken]:  # noqa: C901
         """
         Tokenizes the query
         """


### PR DESCRIPTION
See #423

`sql_metadata/parser.py:127:5: C901 'Parser.tokens' is too complex (9)`