### PR TITLE
ClickHouse: improved tokens handling

### DIFF
--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -463,7 +463,7 @@ class Parser:  # pylint: disable=R0902
                         while token.next_token and not token.is_with_query_end:
                             token = token.next_token
                         is_end_of_with_block = (
-                            token.next_token_not_comment is not None and
+                            token.next_token_not_comment is None or
                             token.next_token_not_comment.normalized
                             in WITH_ENDING_KEYWORDS
                         )

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -463,8 +463,8 @@ class Parser:  # pylint: disable=R0902
                         while token.next_token and not token.is_with_query_end:
                             token = token.next_token
                         is_end_of_with_block = (
-                            token.next_token_not_comment is None or
-                            token.next_token_not_comment.normalized
+                            token.next_token_not_comment is None
+                            or token.next_token_not_comment.normalized
                             in WITH_ENDING_KEYWORDS
                         )
                         if is_end_of_with_block:

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -463,6 +463,7 @@ class Parser:  # pylint: disable=R0902
                         while token.next_token and not token.is_with_query_end:
                             token = token.next_token
                         is_end_of_with_block = (
+                            token.next_token_not_comment is not None and
                             token.next_token_not_comment.normalized
                             in WITH_ENDING_KEYWORDS
                         )
@@ -504,7 +505,7 @@ class Parser:  # pylint: disable=R0902
                 True, value_attribute="is_with_query_end", direction="right"
             )
             query_token = with_start.next_token
-            while query_token != with_end:
+            while query_token is not None and query_token != with_end:
                 current_with_query.append(query_token)
                 query_token = query_token.next_token
             with_query_text = "".join([x.stringified_token for x in current_with_query])

--- a/test/test_with_statements.py
+++ b/test/test_with_statements.py
@@ -470,3 +470,26 @@ def test_comment_between_with_and_query():
     assert parser.columns == ["column_1", "column_2"]
     assert parser.with_queries == {"cte_1": "SELECT column_1, column_2 FROM table_1"}
     assert parser.tables == ["table_1"]
+
+
+def test_identifier_syntax():
+    """
+    Specific for ClickHouse With indentifier syntax
+
+    https://clickhouse.com/docs/en/sql-reference/statements/select/with#examples
+    """
+
+    query = """
+        WITH
+            '2019-08-01 15:23:00' as ts_upper_bound
+        SELECT EventDate, EventTime
+        FROM hits
+        WHERE
+            EventDate = toDate(ts_upper_bound) AND
+            EventTime <= ts_upper_bound;
+    """
+
+    parser = Parser(query)
+
+    assert parser.tables == ["hits"]
+    assert parser.columns == ["EventDate", "EventTime", "ts_upper_bound"]


### PR DESCRIPTION
There's popular DB ClickHouse (https://clickhouse.com/) which has specific syntax for With expressions. So there's available "identifier" syntax which works almost like variables but in SQL way. This syntax looks like a reversed ordinary CTE where calculable expression is set at the left part and its name at the right (https://clickhouse.com/docs/en/sql-reference/statements/select/with#examples).

Currently such syntax causes such an error on `tables` property call:

<details>
  <summary>Traceback</summary>

```python
table_names = Parser(query).tables
^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/sql_metadata/parser.py", line 345, in tables
with_names = self.with_names
^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/sql_metadata/parser.py", line 463, in with_names
token.next_token_not_comment.normalized
AttributeError: 'NoneType' object has no attribute 'normalized'
```
</details>

To avoid such exceptions I propose to treat problem tokens to be end tokens which prevents sql-metadata from crashing