### PR TITLE
Handle the situation where the nested function is empty.

### DIFF
--- a/sql_metadata/token.py
+++ b/sql_metadata/token.py
@@ -187,7 +187,7 @@ class SQLToken:  # pylint: disable=R0902, R0904
         """
         return (
             self.next_token.normalized in [",", "FROM"]
-            and self.previous_token.normalized not in [",", ".", "(", "SELECT"]
+            and self.previous_token.normalized not in ["*", ",", ".", "(", "SELECT"]
             and not self.previous_token.is_keyword
             and (
                 self.last_keyword_normalized == "SELECT"
@@ -229,6 +229,11 @@ class SQLToken:  # pylint: disable=R0902, R0904
             end_of_column = end_of_column.find_nearest_token(
                 [",", "FROM"], value_attribute="normalized", direction="right"
             )
+
+            # early return. end_of_column is EmptyToken.
+            if end_of_column.previous_token is None:
+                return False
+
         return end_of_column.previous_token.normalized == self.normalized
 
     @property

--- a/sql_metadata/token.py
+++ b/sql_metadata/token.py
@@ -229,11 +229,6 @@ class SQLToken:  # pylint: disable=R0902, R0904
             end_of_column = end_of_column.find_nearest_token(
                 [",", "FROM"], value_attribute="normalized", direction="right"
             )
-
-            # early return. end_of_column is EmptyToken.
-            if end_of_column.previous_token is None:
-                return False
-
         return end_of_column.previous_token.normalized == self.normalized
 
     @property

--- a/test/test_column_aliases.py
+++ b/test/test_column_aliases.py
@@ -186,3 +186,15 @@ def test_cast_in_select_with_function():
         "datekey": "testdb.test_table.date",
         "starttimekey": "testdb.test_table.starttime",
     }
+
+
+def test_nested_function():
+    query = """
+        SELECT a * b
+        FROM c
+        WHERE b = (SELECT MAX(b) FROM c);
+    """
+    parser = Parser(query)
+
+    assert parser.columns == ["a", "b"]
+    assert parser.tables == ["c"]


### PR DESCRIPTION
1. Handle the situation where the nested function is empty.
2. parser.columns, mishandle `select aaa * x from ...`