### PR TITLE
fix is_alias_without_as logical error

### DIFF
--- a/sql_metadata/token.py
+++ b/sql_metadata/token.py
@@ -187,7 +187,7 @@ class SQLToken:  # pylint: disable=R0902, R0904
         """
         return (
             self.next_token.normalized in [",", "FROM"]
-            and self.previous_token.normalized not in [",", ".", "(", "SELECT"]
+            and self.previous_token.normalized not in ["*", ",", ".", "(", "SELECT"]
             and not self.previous_token.is_keyword
             and (
                 self.last_keyword_normalized == "SELECT"

--- a/test/test_column_aliases.py
+++ b/test/test_column_aliases.py
@@ -186,3 +186,15 @@ def test_cast_in_select_with_function():
         "datekey": "testdb.test_table.date",
         "starttimekey": "testdb.test_table.starttime",
     }
+
+
+def test_nested_function():
+    query = """
+        SELECT a * b
+        FROM c
+        WHERE b = (SELECT MAX(b) FROM c);
+    """
+    parser = Parser(query)
+
+    assert parser.columns == ["a", "b"]
+    assert parser.tables == ["c"]


### PR DESCRIPTION
For this SQL:

```SQL
SELECT A * B FROM C;
```
Was incorrectly parsed, columns=["A"], the right thing to do is ["A", "B"].