### PR TITLE
Add regression tests for issue #85 (Postgres quoted identifiers)

### DIFF
--- a/test/test_postgress.py
+++ b/test/test_postgress.py
@@ -32,3 +32,22 @@ def test_postgress_quoted_names():
     assert ["name", "test.id"] == parser.columns
     assert {"update": ["name"], "where": ["test.id"]} == parser.columns_dict
     assert "UPDATE test SET name = X WHERE test.id = N" == parser.generalize
+
+
+def test_postgres_quoted_column_only():
+    # regression: https://github.com/macbre/sql-metadata/issues/85
+    # used to raise ValueError: Not supported query type!
+    parser = Parser('SELECT "qouted" FROM foo')
+    assert parser.tables == ["foo"]
+    assert parser.columns == ["qouted"]
+    assert parser.generalize == "SELECT qouted FROM foo"
+
+
+def test_postgres_double_quote_inside_string_literal():
+    # regression: https://github.com/macbre/sql-metadata/issues/85
+    # a literal containing a `"` char used to break parsing
+    query = "select 'some string with quote \" char'"
+    parser = Parser(query)
+    assert parser.tables == []
+    assert parser.columns == []
+    assert parser.generalize == "select X"


### PR DESCRIPTION
## Summary

Verifies that #85 — Postgres quoted identifiers — is fixed under the v3 (sqlglot) parser, and adds regression tests for the two follow-up regressions reported later in the issue thread.

The three queries from the original report (LanDinh) were already covered in `test/test_postgress.py::test_postgress_quoted_names`. The two cases reported afterwards (pro100filipp), which had caused the issue to be reopened, were not covered and now are:

- `SELECT "qouted" FROM foo` — used to raise `ValueError: Not supported query type!`
- `select 'some string with quote " char'` — a literal containing a `"` character used to break parsing

Both now parse correctly; the new tests pin that behavior.

Resolves #85.

## Test plan

- [x] `poetry run pytest test/test_postgress.py -vv` — 3 passed
- [x] `poetry run pytest -q --cov=sql_metadata --cov-report=term-missing` — 269 passed, 100% coverage