### PR TITLE
Handle ragged multi-row INSERT in values_dict

### DIFF
--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -487,8 +487,10 @@ class Parser:
             )
 
         if is_multi:
+            # Pad short rows with None so ragged VALUES tuples do not IndexError.
             self._values_dict = {
-                col: [row[i] for row in values] for i, col in enumerate(columns)
+                col: [row[i] if i < len(row) else None for row in values]
+                for i, col in enumerate(columns)
             }
         else:
             self._values_dict = dict(zip(columns, values))

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -13,6 +13,7 @@ Thin facade that composes the specialised extractors via lazy properties:
 
 import logging
 import re
+from itertools import zip_longest
 from typing import Any
 
 from sqlglot import exp
@@ -487,10 +488,10 @@ class Parser:
             )
 
         if is_multi:
-            # Pad short rows with None so ragged VALUES tuples do not IndexError.
+            # zip_longest pads short VALUES rows with None (avoids IndexError).
             self._values_dict = {
-                col: [row[i] if i < len(row) else None for row in values]
-                for i, col in enumerate(columns)
+                col: list(col_vals)
+                for col, col_vals in zip(columns, zip_longest(*values, fillvalue=None))
             }
         else:
             self._values_dict = dict(zip(columns, values))

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -13,7 +13,6 @@ Thin facade that composes the specialised extractors via lazy properties:
 
 import logging
 import re
-from itertools import zip_longest
 from typing import Any
 
 from sqlglot import exp
@@ -488,19 +487,15 @@ class Parser:
             )
 
         if is_multi:
-            # Pad short rows to column width so trailing columns stay present.
-            transposed = list(zip_longest(*values, fillvalue=None))
-            n_rows = len(values)
             self._values_dict = {
-                col: (
-                    list(transposed[i])
-                    if i < len(transposed)
-                    else [None] * n_rows
-                )
+                col: [row[i] if i < len(row) else None for row in values]
                 for i, col in enumerate(columns)
             }
         else:
-            self._values_dict = dict(zip(columns, values))
+            self._values_dict = {
+                col: (values[i] if i < len(values) else None)
+                for i, col in enumerate(columns)
+            }
         return self._values_dict
 
     @property

--- a/sql_metadata/parser.py
+++ b/sql_metadata/parser.py
@@ -488,10 +488,16 @@ class Parser:
             )
 
         if is_multi:
-            # zip_longest pads short VALUES rows with None (avoids IndexError).
+            # Pad short rows to column width so trailing columns stay present.
+            transposed = list(zip_longest(*values, fillvalue=None))
+            n_rows = len(values)
             self._values_dict = {
-                col: list(col_vals)
-                for col, col_vals in zip(columns, zip_longest(*values, fillvalue=None))
+                col: (
+                    list(transposed[i])
+                    if i < len(transposed)
+                    else [None] * n_rows
+                )
+                for i, col in enumerate(columns)
             }
         else:
             self._values_dict = dict(zip(columns, values))

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -151,6 +151,13 @@ def test_insert_multi_row_values():
     assert p.values_dict == {"field1": [1, 3], "field2": [2, 4]}
 
 
+def test_insert_multi_row_ragged_values_dict():
+    """Ragged multi-row VALUES must not IndexError in values_dict."""
+    p = Parser("INSERT INTO t (a, b) VALUES (1, 2), (3)")
+    assert p.values == [[1, 2], [3]]
+    assert p.values_dict == {"a": [1, 3], "b": [2, None]}
+
+
 def test_insert_with_expression_value():
     """INSERT with a function call in VALUES uses str(val) fallback."""
     p = Parser("INSERT INTO t (a) VALUES (CURRENT_TIMESTAMP)")

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -165,6 +165,13 @@ def test_insert_multi_row_all_rows_shorter_than_columns():
     assert p.values_dict == {"a": [1, 2], "b": [None, None]}
 
 
+def test_insert_single_row_shorter_than_columns():
+    """Single-row VALUES shorter than the column list still yields all keys."""
+    p = Parser("INSERT INTO t (a, b) VALUES (1)")
+    assert p.values == [1]
+    assert p.values_dict == {"a": 1, "b": None}
+
+
 def test_insert_with_expression_value():
     """INSERT with a function call in VALUES uses str(val) fallback."""
     p = Parser("INSERT INTO t (a) VALUES (CURRENT_TIMESTAMP)")

--- a/test/test_values.py
+++ b/test/test_values.py
@@ -158,6 +158,13 @@ def test_insert_multi_row_ragged_values_dict():
     assert p.values_dict == {"a": [1, 3], "b": [2, None]}
 
 
+def test_insert_multi_row_all_rows_shorter_than_columns():
+    """Every VALUES row shorter than the column list still yields all keys."""
+    p = Parser("INSERT INTO t (a, b) VALUES (1), (2)")
+    assert p.values == [[1], [2]]
+    assert p.values_dict == {"a": [1, 2], "b": [None, None]}
+
+
 def test_insert_with_expression_value():
     """INSERT with a function call in VALUES uses str(val) fallback."""
     p = Parser("INSERT INTO t (a) VALUES (CURRENT_TIMESTAMP)")


### PR DESCRIPTION
Parser.values_dict hits IndexError when INSERT multi-row ragged VALUES (1,2),(3). This PR fixes the regression with a focused test covering the case. claimed