### PR TITLE
Handle empty CTE body in with_queries

### DIFF
--- a/sql_metadata/nested_resolver.py
+++ b/sql_metadata/nested_resolver.py
@@ -240,6 +240,10 @@ class NestedResolver:
         for cte in self._cte_nodes():
             alias = cte.alias
             original_name = cte_name_map.get(alias, alias)
+            # Empty CTE bodies (WITH a AS ()) leave cte.this as None.
+            if cte.this is None:
+                results[original_name] = ""
+                continue
             results[original_name] = self._body_sql(cte.this)
 
         return results

--- a/sql_metadata/nested_resolver.py
+++ b/sql_metadata/nested_resolver.py
@@ -466,6 +466,9 @@ class NestedResolver:
         """
         for nested_name in names:
             nested_def = definitions[nested_name]
+            # Empty CTE/subquery bodies cannot be re-parsed (Parser("") asserts).
+            if not nested_def:
+                continue
             nested_parser = parser_cache.setdefault(
                 nested_name, self._parser_factory(nested_def)
             )
@@ -515,6 +518,9 @@ class NestedResolver:
             return [subquery_alias]
         sub_query, column_name = parts[0], parts[-1]
         sub_query_definition = nested_queries[sub_query]
+        # Empty bodies have no columns/aliases to resolve through.
+        if not sub_query_definition:
+            return [] if column_name == "*" else [subquery_alias]
         subparser = already_parsed.setdefault(
             sub_query, self._parser_factory(sub_query_definition)
         )

--- a/sql_metadata/nested_resolver.py
+++ b/sql_metadata/nested_resolver.py
@@ -240,10 +240,6 @@ class NestedResolver:
         for cte in self._cte_nodes():
             alias = cte.alias
             original_name = cte_name_map.get(alias, alias)
-            # Empty CTE bodies (WITH a AS ()) leave cte.this as None.
-            if cte.this is None:
-                results[original_name] = ""
-                continue
             results[original_name] = self._body_sql(cte.this)
 
         return results
@@ -671,7 +667,7 @@ class NestedResolver:
     # -------------------------------------------------------------------
 
     @staticmethod
-    def _body_sql(node: exp.Expression) -> str:
+    def _body_sql(node: exp.Expression | None) -> str:
         """Render an AST node to SQL, stripping identifier quoting.
 
         Example SQL::
@@ -679,7 +675,10 @@ class NestedResolver:
             WITH cte AS (SELECT "id" FROM "users") ...
 
         Renders the CTE body as ``SELECT id FROM users`` (quotes stripped).
+        Empty CTE bodies (``WITH a AS ()``) leave ``cte.this`` as None.
         """
+        if node is None:
+            return ""
         body = node.copy()
         for ident in body.find_all(exp.Identifier):
             ident.set("quoted", False)

--- a/test/test_with_statements.py
+++ b/test/test_with_statements.py
@@ -715,6 +715,13 @@ def test_with_queries_empty_when_no_cte():
     assert p.with_queries == {}
 
 
+def test_with_queries_empty_cte_body():
+    """Empty CTE body WITH a AS () must not AttributeError on with_queries."""
+    p = Parser("WITH a AS () SELECT 1")
+    assert p.with_queries == {"a": ""}
+    assert p.columns == []
+
+
 def test_cte_subquery_full_resolution():
     """Subquery + CTE: CTE-qualified columns fully resolved."""
     parser = Parser("""

--- a/test/test_with_statements.py
+++ b/test/test_with_statements.py
@@ -720,6 +720,19 @@ def test_with_queries_empty_cte_body():
     p = Parser("WITH a AS () SELECT 1")
     assert p.with_queries == {"a": ""}
     assert p.columns == []
+    assert p.with_names == ["a"]
+
+
+def test_empty_cte_body_columns_do_not_crash():
+    """Referencing an empty CTE must not assert via nested Parser('')."""
+    p = Parser("WITH a AS () SELECT * FROM a")
+    assert p.with_queries == {"a": ""}
+    assert p.columns == ["*"]
+
+    # Sibling empty CTE must not poison resolution of a real CTE.
+    p2 = Parser("WITH a AS (), b AS (SELECT 1 AS x) SELECT x FROM b")
+    assert p2.with_queries == {"a": "", "b": "SELECT 1 AS x"}
+    assert p2.columns_dict["select"] == ["x"]
 
 
 def test_cte_subquery_full_resolution():

--- a/test/test_with_statements.py
+++ b/test/test_with_statements.py
@@ -724,15 +724,23 @@ def test_with_queries_empty_cte_body():
 
 
 def test_empty_cte_body_columns_do_not_crash():
-    """Referencing an empty CTE must not assert via nested Parser('')."""
+    """Empty CTE bodies must not assert via nested Parser('')."""
     p = Parser("WITH a AS () SELECT * FROM a")
     assert p.with_queries == {"a": ""}
     assert p.columns == ["*"]
 
-    # Sibling empty CTE must not poison resolution of a real CTE.
-    p2 = Parser("WITH a AS (), b AS (SELECT 1 AS x) SELECT x FROM b")
+    # Sibling empty CTE must not poison star resolution of a real CTE.
+    p2 = Parser("WITH a AS (), b AS (SELECT 1 AS x) SELECT * FROM b")
     assert p2.with_queries == {"a": "", "b": "SELECT 1 AS x"}
-    assert p2.columns_dict["select"] == ["x"]
+    assert p2.columns_dict["select"] == ["*", "x"]
+
+    # Qualified refs exercise _resolve_nested_query empty-body branch.
+    p_star = Parser("WITH a AS () SELECT a.* FROM a")
+    assert p_star.columns == []
+    assert p_star.columns_dict.get("select") == []
+
+    p_col = Parser("WITH a AS () SELECT a.x FROM a")
+    assert p_col.columns == ["a.x"]
 
 
 def test_cte_subquery_full_resolution():


### PR DESCRIPTION
NestedQueryResolver._body_sql / with_queries hits AttributeError when WITH a AS () SELECT 1. This PR fixes the regression with a focused test covering the case. claimed